### PR TITLE
Dataset accessor API refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ bin/
 # doc
 doc/_build
 doc/_api_generated
+
+# emacs
+.projectile

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -38,7 +38,6 @@ properties listed below. Proper use of this accessor should be like:
    :toctree: _api_generated/
    :template: autosummary/accessor_attribute.rst
 
-   Dataset.xsimlab.model
    Dataset.xsimlab.clock_coords
    Dataset.xsimlab.master_clock_dim
    Dataset.xsimlab.snapshot_vars
@@ -49,7 +48,6 @@ properties listed below. Proper use of this accessor should be like:
    :toctree: _api_generated/
    :template: autosummary/accessor_method.rst
 
-   Dataset.xsimlab.use_model
    Dataset.xsimlab.update_clocks
    Dataset.xsimlab.update_vars
    Dataset.xsimlab.filter_vars

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -40,7 +40,7 @@ properties listed below. Proper use of this accessor should be like:
 
    Dataset.xsimlab.model
    Dataset.xsimlab.clock_coords
-   Dataset.xsimlab.dim_master_clock
+   Dataset.xsimlab.master_clock_dim
    Dataset.xsimlab.snapshot_vars
 
 **Methods**

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -50,6 +50,8 @@ properties listed below. Proper use of this accessor should be like:
    :template: autosummary/accessor_method.rst
 
    Dataset.xsimlab.use_model
+   Dataset.xsimlab.update_clocks
+   Dataset.xsimlab.update_vars
    Dataset.xsimlab.set_master_clock
    Dataset.xsimlab.set_snapshot_clock
    Dataset.xsimlab.set_input_vars

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -52,6 +52,7 @@ properties listed below. Proper use of this accessor should be like:
    Dataset.xsimlab.use_model
    Dataset.xsimlab.update_clocks
    Dataset.xsimlab.update_vars
+   Dataset.xsimlab.filter_vars
    Dataset.xsimlab.set_master_clock
    Dataset.xsimlab.set_snapshot_clock
    Dataset.xsimlab.set_input_vars

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -53,10 +53,6 @@ properties listed below. Proper use of this accessor should be like:
    Dataset.xsimlab.update_clocks
    Dataset.xsimlab.update_vars
    Dataset.xsimlab.filter_vars
-   Dataset.xsimlab.set_master_clock
-   Dataset.xsimlab.set_snapshot_clock
-   Dataset.xsimlab.set_input_vars
-   Dataset.xsimlab.set_snapshot_vars
    Dataset.xsimlab.run
 
 Model

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -205,6 +205,7 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.6/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
     'xarray': ('http://xarray.pydata.org/en/stable/', None)
 }
 

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from .variable.base import (AbstractVariable, Variable, ForeignVariable,
                             VariableList, VariableGroup)
 from .process import Process
-from .utils import AttrMapping
+from .utils import AttrMapping, ContextMixin
 from .formatting import _calculate_col_width, pretty_print, maybe_truncate
 
 
@@ -159,7 +159,7 @@ def _sort_processes(dep_processes):
     return ordered
 
 
-class Model(AttrMapping):
+class Model(AttrMapping, ContextMixin):
     """An immutable collection (mapping) of process units that together
     form a computational model.
 

--- a/xsimlab/tests/conftest.py
+++ b/xsimlab/tests/conftest.py
@@ -157,14 +157,15 @@ def model_repr():
 
 @pytest.fixture
 def input_dataset():
+    clock_key = SimlabAccessor._clock_key
     mclock_key = SimlabAccessor._master_clock_key
-    sclock_key = SimlabAccessor._snapshot_clock_key
     svars_key = SimlabAccessor._snapshot_vars_key
 
     ds = xr.Dataset()
 
-    ds['clock'] = ('clock', [0, 2, 4, 6, 8], {mclock_key: np.uint8(True)})
-    ds['out'] = ('out', [0, 4, 8], {sclock_key: np.uint8(True)})
+    ds['clock'] = ('clock', [0, 2, 4, 6, 8],
+                   {clock_key: np.uint8(True), mclock_key: np.uint8(True)})
+    ds['out'] = ('out', [0, 4, 8], {clock_key: np.uint8(True)})
 
     ds['grid__x_size'] = ((), 10, {'description': 'grid size'})
     ds['quantity__quantity'] = ('x', np.zeros(10),

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -41,18 +41,18 @@ class TestSimlabAccessor(object):
         ds = xr.Dataset()
         assert ds.xsimlab.master_clock_dim is None
 
-    def test_master_clock_dim_setter(self):
+    def test_set_master_clock_dim(self):
         ds = xr.Dataset(coords={'clock': [1, 2], 'clock2': [3, 4]})
 
-        ds.xsimlab.master_clock_dim = 'clock'
+        ds.xsimlab._set_master_clock_dim('clock')
         assert self._master_clock_key in ds.clock.attrs
 
-        ds.xsimlab.master_clock_dim = 'clock2'
+        ds.xsimlab._set_master_clock_dim('clock2')
         assert self._master_clock_key not in ds.clock.attrs
         assert self._master_clock_key in ds.clock2.attrs
 
         with pytest.raises(KeyError):
-            ds.xsimlab.master_clock_dim = 'invalid_clock'
+            ds.xsimlab._set_master_clock_dim('invalid_clock')
 
     def test_set_master_clock(self):
         data = [0, 2, 4, 6, 8]

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -29,29 +29,29 @@ class TestSimlabAccessor(object):
         )
         assert set(ds.xsimlab.clock_coords) == {'mclock', 'sclock'}
 
-    def test_dim_master_clock(self):
+    def test_master_clock_dim(self):
         attrs = {self._master_clock_key: 1}
         ds = xr.Dataset(coords={'clock': ('clock', [1, 2], attrs)})
 
-        assert ds.xsimlab.dim_master_clock == 'clock'
-        assert ds.xsimlab._dim_master_clock == 'clock'  # cache
-        assert ds.xsimlab.dim_master_clock == 'clock'   # get cached value
+        assert ds.xsimlab.master_clock_dim == 'clock'
+        assert ds.xsimlab._master_clock_dim == 'clock'  # cache
+        assert ds.xsimlab.master_clock_dim == 'clock'   # get cached value
 
         ds = xr.Dataset()
-        assert ds.xsimlab.dim_master_clock is None
+        assert ds.xsimlab.master_clock_dim is None
 
-    def test_dim_master_clock_setter(self):
+    def test_master_clock_dim_setter(self):
         ds = xr.Dataset(coords={'clock': [1, 2], 'clock2': [3, 4]})
 
-        ds.xsimlab.dim_master_clock = 'clock'
+        ds.xsimlab.master_clock_dim = 'clock'
         assert self._master_clock_key in ds.clock.attrs
 
-        ds.xsimlab.dim_master_clock = 'clock2'
+        ds.xsimlab.master_clock_dim = 'clock2'
         assert self._master_clock_key not in ds.clock.attrs
         assert self._master_clock_key in ds.clock2.attrs
 
         with pytest.raises(KeyError):
-            ds.xsimlab.dim_master_clock = 'invalid_clock'
+            ds.xsimlab.master_clock_dim = 'invalid_clock'
 
     def test_set_master_clock(self):
         data = [0, 2, 4, 6, 8]
@@ -270,7 +270,7 @@ def test_create_setup(model, input_dataset):
     assert "master clock dimension name" in str(excinfo.value)
 
     ds = create_setup(model=model, clocks={'clock': {'data': [0, 1, 2]}})
-    assert ds.xsimlab.dim_master_clock == 'clock'
+    assert ds.xsimlab.master_clock_dim == 'clock'
 
     ds = create_setup(model=model,
                       clocks={

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -68,7 +68,7 @@ class TestSimlabAccessor(object):
         ]
         for kwargs in valid_kwargs:
             ds = xr.Dataset()
-            ds.xsimlab.set_master_clock('clock', **kwargs)
+            ds.xsimlab._set_master_clock('clock', **kwargs)
             np.testing.assert_array_equal(ds.clock.values, data)
 
         invalid_kwargs = [
@@ -79,88 +79,86 @@ class TestSimlabAccessor(object):
         for kwargs in invalid_kwargs:
             with pytest.raises(ValueError) as excinfo:
                 ds = xr.Dataset()
-                ds.xsimlab.set_master_clock('clock', **kwargs)
+                ds.xsimlab._set_master_clock('clock', **kwargs)
             assert "Invalid combination" in str(excinfo.value)
 
         ds = xr.Dataset()
-        ds.xsimlab.set_master_clock('clock', data=data,
-                                    units='years since 1-1-1 0:0:0',
-                                    calendar='365_day')
+        ds.xsimlab._set_master_clock('clock', data=data,
+                                     units='years since 1-1-1 0:0:0',
+                                     calendar='365_day')
         assert self._master_clock_key in ds.clock.attrs
         assert ds.clock.attrs['units'] == 'years since 1-1-1 0:0:0'
         assert ds.clock.attrs['calendar'] == '365_day'
 
         with pytest.raises(ValueError) as excinfo:
-            ds.xsimlab.set_master_clock('clock', data=data)
+            ds.xsimlab._set_master_clock('clock', data=data)
         assert "already exists" in str(excinfo.value)
 
         ds = xr.Dataset()
         da = xr.DataArray(data, dims='other_dim')
         with pytest.raises(ValueError) as excinfo:
-            ds.xsimlab.set_master_clock('clock', data=da)
+            ds.xsimlab._set_master_clock('clock', data=da)
         assert "expected dimension" in str(excinfo.value)
 
     def test_set_snapshot_clock(self):
         with pytest.raises(ValueError) as excinfo:
             ds = xr.Dataset()
-            ds.xsimlab.set_snapshot_clock('snap_clock', data=[1, 2])
+            ds.xsimlab._set_snapshot_clock('snap_clock', data=[1, 2])
         assert "no master clock" in str(excinfo.value)
 
         ds = xr.Dataset()
-        ds.xsimlab.set_master_clock('clock', data=[0, 2, 4, 6, 8],
-                                    units='years since 1-1-1 0:0:0',
-                                    calendar='365_day')
+        ds.xsimlab._set_master_clock('clock', data=[0, 2, 4, 6, 8],
+                                     units='years since 1-1-1 0:0:0',
+                                     calendar='365_day')
 
-        ds.xsimlab.set_snapshot_clock('snap_clock', end=8, step=4)
+        ds.xsimlab._set_snapshot_clock('snap_clock', end=8, step=4)
         np.testing.assert_array_equal(ds['snap_clock'], [0, 4, 8])
         assert self._clock_key in ds['snap_clock'].attrs
         assert 'units' in ds['snap_clock'].attrs
         assert 'calendar' in ds['snap_clock'].attrs
 
-        ds.xsimlab.set_snapshot_clock('snap_clock', data=[0, 3, 8])
+        ds.xsimlab._set_snapshot_clock('snap_clock', data=[0, 3, 8])
         np.testing.assert_array_equal(ds['snap_clock'], [0, 4, 8])
 
         with pytest.raises(KeyError):
-            ds.xsimlab.set_snapshot_clock('snap_clock', data=[0, 3, 8],
-                                          auto_adjust=False)
+            ds.xsimlab._set_snapshot_clock('snap_clock', data=[0, 3, 8],
+                                           auto_adjust=False)
 
     def test_set_input_vars(self, model):
         ds = xr.Dataset()
 
-        with pytest.raises(ValueError) as excinfo:
-            ds.xsimlab.set_input_vars('process', var=1)
-        assert "no model attached" in str(excinfo.value)
-
         ds.xsimlab.use_model(model)
         with pytest.raises(KeyError) as excinfo:
-            ds.xsimlab.set_input_vars('invalid_process', var=1)
+            ds.xsimlab._set_input_vars(model, 'invalid_process', var=1)
         assert "no process named" in str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
-            ds.xsimlab.set_input_vars('some_process', some_param=0,
-                                      invalid_var=1)
+            ds.xsimlab._set_input_vars(model, 'some_process', some_param=0,
+                                       invalid_var=1)
         assert "not valid input variables" in str(excinfo.value)
 
-        ds.xsimlab.set_input_vars('quantity', quantity=('x', np.zeros(10)))
+        ds.xsimlab._set_input_vars(model, 'quantity',
+                                   quantity=('x', np.zeros(10)))
         expected = xr.DataArray(data=np.zeros(10), dims='x')
         assert "quantity__quantity" in ds
         xr.testing.assert_equal(ds['quantity__quantity'], expected)
 
         # test time and parameter dimensions
-        ds.xsimlab.set_input_vars(model.some_process, some_param=[1, 2])
+        ds.xsimlab._set_input_vars(model, model.some_process, some_param=[1, 2])
         expected = xr.DataArray(data=[1, 2], dims='some_process__some_param',
                                 coords={'some_process__some_param': [1, 2]})
         xr.testing.assert_equal(ds['some_process__some_param'], expected)
         del ds['some_process__some_param']
 
         ds['clock'] = ('clock', [0, 1], {self._master_clock_key: 1})
-        ds.xsimlab.set_input_vars('some_process', some_param=('clock', [1, 2]))
+        ds.xsimlab._set_input_vars(model, 'some_process',
+                                   some_param=('clock', [1, 2]))
         expected = xr.DataArray(data=[1, 2], dims='clock',
                                 coords={'clock': [0, 1]})
         xr.testing.assert_equal(ds['some_process__some_param'], expected)
 
         # test optional
-        ds.xsimlab.set_input_vars('grid')
+        ds.xsimlab._set_input_vars(model, 'grid')
         expected = xr.DataArray(data=5)
         xr.testing.assert_equal(ds['grid__x_size'], expected)
 
@@ -171,36 +169,34 @@ class TestSimlabAccessor(object):
         ds['snap_clock'] = ('snap_clock', [0, 4, 8], {self._clock_key: 1})
         ds['not_a_clock'] = ('not_a_clock', [0, 1])
 
-        with pytest.raises(ValueError) as excinfo:
-            ds.xsimlab.set_snapshot_vars(None, process='var')
-        assert "no model attached" in str(excinfo.value)
-
         ds.xsimlab.use_model(model)
         with pytest.raises(KeyError) as excinfo:
-            ds.xsimlab.set_snapshot_vars(None, invalid_process='var')
+            ds.xsimlab._set_snapshot_vars(model, None, invalid_process='var')
         assert "no process named" in str(excinfo.value)
 
         with pytest.raises(KeyError) as excinfo:
-            ds.xsimlab.set_snapshot_vars(None, quantity='invalid_var')
+            ds.xsimlab._set_snapshot_vars(model, None, quantity='invalid_var')
         assert "has no variable" in str(excinfo.value)
 
-        ds.xsimlab.set_snapshot_vars(None, grid='x')
+        ds.xsimlab._set_snapshot_vars(model, None, grid='x')
         assert ds.attrs[self._snapshot_vars_key] == 'grid__x'
 
-        ds.xsimlab.set_snapshot_vars('clock', some_process='some_effect',
-                                     quantity='quantity')
+        ds.xsimlab._set_snapshot_vars(model, 'clock',
+                                      some_process='some_effect',
+                                      quantity='quantity')
         expected = {'some_process__some_effect', 'quantity__quantity'}
         actual = set(ds['clock'].attrs[self._snapshot_vars_key].split(','))
         assert actual == expected
 
-        ds.xsimlab.set_snapshot_vars('snap_clock',
-                                     other_process=('other_effect', 'x2'))
+        ds.xsimlab._set_snapshot_vars(model, 'snap_clock',
+                                      other_process=('other_effect', 'x2'))
         expected = {'other_process__other_effect', 'other_process__x2'}
         actual = set(ds['snap_clock'].attrs[self._snapshot_vars_key].split(','))
         assert actual == expected
 
         with pytest.raises(ValueError) as excinfo:
-            ds.xsimlab.set_snapshot_vars('not_a_clock', quantity='quantity')
+            ds.xsimlab._set_snapshot_vars(model, 'not_a_clock',
+                                          quantity='quantity')
         assert "not a valid clock" in str(excinfo.value)
 
     def test_snapshot_vars(self, model):
@@ -213,10 +209,10 @@ class TestSimlabAccessor(object):
                              {self._clock_key: 1})
 
         ds.xsimlab.use_model(model)
-        ds.xsimlab.set_snapshot_vars(None, grid='x')
-        ds.xsimlab.set_snapshot_vars('clock', quantity='quantity')
-        ds.xsimlab.set_snapshot_vars('snap_clock',
-                                     other_process=('other_effect', 'x2'))
+        ds.xsimlab._set_snapshot_vars(model, None, grid='x')
+        ds.xsimlab._set_snapshot_vars(model, 'clock', quantity='quantity')
+        ds.xsimlab._set_snapshot_vars(model, 'snap_clock',
+                                      other_process=('other_effect', 'x2'))
 
         expected = {None: set([('grid', 'x')]),
                     'clock': set([('quantity', 'quantity')]),

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -288,8 +288,7 @@ def test_create_setup(model, input_dataset):
         input_vars={
             'grid': {'x_size': 10},
             'quantity': {'quantity': ('x', np.zeros(10))},
-            # omit input below, should be set anyway using default value
-            # 'some_process': {'some_param': 1},
+            'some_process': {'some_param': 1},
             'other_process': {'other_param': ('clock', [1, 2, 3, 4, 5])}
         },
         clocks={

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -15,22 +15,23 @@ def test_filter_accessor():
 
 class TestSimlabAccessor(object):
 
+    _clock_key = xr_accessor.SimlabAccessor._clock_key
     _master_clock_key = xr_accessor.SimlabAccessor._master_clock_key
-    _snapshot_clock_key = xr_accessor.SimlabAccessor._snapshot_clock_key
     _snapshot_vars_key = xr_accessor.SimlabAccessor._snapshot_vars_key
 
     def test_clock_coords(self):
         ds = xr.Dataset(
             coords={
-                'mclock': ('mclock', [0, 1, 2], {self._master_clock_key: 1}),
-                'sclock': ('sclock', [0, 2], {self._snapshot_clock_key: 1}),
+                'mclock': ('mclock', [0, 1, 2],
+                           {self._clock_key: 1, self._master_clock_key: 1}),
+                'sclock': ('sclock', [0, 2], {self._clock_key: 1}),
                 'no_clock': ('no_clock', [3, 4])
             }
         )
         assert set(ds.xsimlab.clock_coords) == {'mclock', 'sclock'}
 
     def test_master_clock_dim(self):
-        attrs = {self._master_clock_key: 1}
+        attrs = {self._clock_key: 1, self._master_clock_key: 1}
         ds = xr.Dataset(coords={'clock': ('clock', [1, 2], attrs)})
 
         assert ds.xsimlab.master_clock_dim == 'clock'
@@ -112,7 +113,7 @@ class TestSimlabAccessor(object):
 
         ds.xsimlab.set_snapshot_clock('snap_clock', end=8, step=4)
         np.testing.assert_array_equal(ds['snap_clock'], [0, 4, 8])
-        assert self._snapshot_clock_key in ds['snap_clock'].attrs
+        assert self._clock_key in ds['snap_clock'].attrs
         assert 'units' in ds['snap_clock'].attrs
         assert 'calendar' in ds['snap_clock'].attrs
 
@@ -165,9 +166,9 @@ class TestSimlabAccessor(object):
 
     def test_set_snapshot_vars(self, model):
         ds = xr.Dataset()
-        ds['clock'] = ('clock', [0, 2, 4, 6, 8], {self._master_clock_key: 1})
-        ds['snap_clock'] = ('snap_clock', [0, 4, 8],
-                            {self._snapshot_clock_key: 1})
+        ds['clock'] = ('clock', [0, 2, 4, 6, 8],
+                       {self._clock_key: 1, self._master_clock_key: 1})
+        ds['snap_clock'] = ('snap_clock', [0, 4, 8], {self._clock_key: 1})
         ds['not_a_clock'] = ('not_a_clock', [0, 1])
 
         with pytest.raises(ValueError) as excinfo:
@@ -204,12 +205,12 @@ class TestSimlabAccessor(object):
 
     def test_snapshot_vars(self, model):
         ds = xr.Dataset()
-        ds['clock'] = ('clock', [0, 2, 4, 6, 8], {self._master_clock_key: 1})
-        ds['snap_clock'] = ('snap_clock', [0, 4, 8],
-                            {self._snapshot_clock_key: 1})
+        ds['clock'] = ('clock', [0, 2, 4, 6, 8],
+                       {self._clock_key: 1, self._master_clock_key: 1})
+        ds['snap_clock'] = ('snap_clock', [0, 4, 8], {self._clock_key: 1})
         # snapshot clock with no snapshot variable (attribute) set
         ds['snap_clock2'] = ('snap_clock2', [0, 8],
-                             {self._snapshot_clock_key: 1})
+                             {self._clock_key: 1})
 
         ds.xsimlab.use_model(model)
         ds.xsimlab.set_snapshot_vars(None, grid='x')

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -127,7 +127,6 @@ class TestSimlabAccessor(object):
     def test_set_input_vars(self, model):
         ds = xr.Dataset()
 
-        ds.xsimlab.use_model(model)
         with pytest.raises(KeyError) as excinfo:
             ds.xsimlab._set_input_vars(model, 'invalid_process', var=1)
         assert "no process named" in str(excinfo.value)
@@ -169,7 +168,6 @@ class TestSimlabAccessor(object):
         ds['snap_clock'] = ('snap_clock', [0, 4, 8], {self._clock_key: 1})
         ds['not_a_clock'] = ('not_a_clock', [0, 1])
 
-        ds.xsimlab.use_model(model)
         with pytest.raises(KeyError) as excinfo:
             ds.xsimlab._set_snapshot_vars(model, None, invalid_process='var')
         assert "no process named" in str(excinfo.value)
@@ -208,7 +206,6 @@ class TestSimlabAccessor(object):
         ds['snap_clock2'] = ('snap_clock2', [0, 8],
                              {self._clock_key: 1})
 
-        ds.xsimlab.use_model(model)
         ds.xsimlab._set_snapshot_vars(model, None, grid='x')
         ds.xsimlab._set_snapshot_vars(model, 'clock', quantity='quantity')
         ds.xsimlab._set_snapshot_vars(model, 'snap_clock',

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -222,14 +222,12 @@ class TestSimlabAccessor(object):
         assert actual == expected
 
     def test_run(self, model, input_dataset):
-        input_dataset.xsimlab.use_model(model)
-
         # safe mode True: model cloned -> values not set in original model
-        _ = input_dataset.xsimlab.run()
+        _ = input_dataset.xsimlab.run(model=model)
         assert model.quantity.quantity.value is None
 
         # safe mode False: model not cloned -> values set in original model
-        _ = input_dataset.xsimlab.run(safe_mode=False)
+        _ = input_dataset.xsimlab.run(model=model, safe_mode=False)
         assert model.quantity.quantity.value is not None
 
     def test_run_multi(self):
@@ -240,9 +238,9 @@ class TestSimlabAccessor(object):
 
 
 def test_create_setup(model, input_dataset):
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(TypeError) as excinfo:
         create_setup()
-    assert "no model provided" in str(excinfo.value)
+    assert "No context on context stack" in str(excinfo.value)
 
     expected = xr.Dataset()
     actual = create_setup(model=model)

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -598,7 +598,7 @@ class SimlabAccessor(object):
 
         return ds
 
-    def run(self, safe_mode=True):
+    def run(self, model=None, safe_mode=True):
         """Run the model.
 
         Parameters
@@ -614,13 +614,13 @@ class SimlabAccessor(object):
             Another Dataset with model inputs and outputs.
 
         """
-        if self._model is None:
-            raise ValueError("No model attached to this Dataset")
+        if model is None:
+            if self._model is None:
+                raise ValueError("No model attached to this Dataset")
+            model = self._model
 
         if safe_mode:
-            model = self._model.clone()
-        else:
-            model = self._model
+            model = model.clone()
 
         ds_model_interface = DatasetModelInterface(model, self._obj)
         out_ds = ds_model_interface.run_model()

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -641,8 +641,8 @@ class SimlabAccessor(object):
         raise NotImplementedError()
 
 
-def create_setup(model=None, input_vars=None, clocks=None, master_clock=None,
-                 snapshot_vars=None):
+def create_setup(model=None, clocks=None, master_clock=None,
+                 input_vars=None, snapshot_vars=None):
     """Create a specific setup for model runs.
 
     This convenient function creates a new xarray.Dataset object with model
@@ -653,12 +653,6 @@ def create_setup(model=None, input_vars=None, clocks=None, master_clock=None,
     ----------
     model : Model object, optional
         Create a simulation setup for this model.
-    input_vars : dict of dicts, optional
-        Used to set values for model inputs. The structure of the dict of
-        dicts looks like {'process_name': {'var_name': value, ...}, ...}.
-        The given values are anything that can be easily converted to
-        xarray.Variable objects, e.g., single values, array-like,
-        (dims, data, attrs) tuples or xarray objects.
     clocks : dict of dicts, optional
         Used to create on or several clock coordinates. The structure of the
         dict of dicts looks like {'dim': {kwarg: value, ...}, ...}.
@@ -668,8 +662,14 @@ def create_setup(model=None, input_vars=None, clocks=None, master_clock=None,
     master_clock : str or dict, optional
         Name of the clock coordinate (dimension) that will be used as master
         clock. A dictionary with at least a 'dim' key can be provided instead.
-        Time units and calendar (CF-conventions) can be set manually using
+        Time units and calendar (CF-conventions) can also be set using
         'units' and 'calendar' keys, respectively.
+    input_vars : dict of dicts, optional
+        Used to set values for model inputs. The structure of the dict of
+        dicts looks like {'process_name': {'var_name': value, ...}, ...}.
+        The given values are anything that can be easily converted to
+        xarray.Variable objects, e.g., single values, array-like,
+        (dims, data, attrs) tuples or xarray objects.
     snapshot_vars : dict of dicts, optional
         Model variables to save as simulation snapshots. The structure of the
         dict of dicts looks like

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -582,15 +582,16 @@ class SimlabAccessor(object):
             except ValueError:
                 continue
 
-            if model.is_input((proc_name, var_name)):
+            if not model.is_input((proc_name, var_name)):
                 drop_variables.append(xr_var_name)
 
         ds = self._obj.drop(drop_variables)
+        ds.xsimlab.use_model(model)  # TODO: remove this
 
         for dim, var_list in self.snapshot_vars.items():
             var_dict = defaultdict(list)
             for proc_name, var_name in var_list:
-                if model.is_input((proc_name, var_name)):
+                if model.get(proc_name, {}).get(var_name, False):
                     var_dict[proc_name].append(var_name)
 
             ds.xsimlab.set_snapshot_vars(dim, **var_dict)

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -422,7 +422,7 @@ class SimlabAccessor(object):
     def update_clocks(self, model=None, clocks=None, master_clock=None):
         """Update clock coordinates.
 
-        Use this to add or replace a whole set of master and snapshot clock
+        It adds or replaces a whole set of master and snapshot clock
         coordinates. Snapshot-related attributes will be copied from existing
         coordinates, if any.
 
@@ -436,9 +436,9 @@ class SimlabAccessor(object):
             See :meth:`xsimlab.create_setup` for more info.
         master_clock : str or dict, optional
             Name of the clock coordinate (dimension) that will be used as master
-            clock. A dictionary with at least a 'dim' key can also be provided.
-            Time units and calendar (CF-conventions) can be set manually using
-            'units' and 'calendar' keys, respectively.
+            clock. A dictionary with at least a 'dim' key can be provided
+            instead. Time units and calendar (CF-conventions) can be set
+            manually using 'units' and 'calendar' keys, respectively.
 
         Returns
         -------
@@ -590,9 +590,9 @@ def create_setup(model=None, input_vars=None, clocks=None, master_clock=None,
                  snapshot_vars=None):
     """Create a specific setup for model runs.
 
-    This is a convenient function that creates a new xarray.Dataset object
-    with model input values, time steps and model output variables (including
-    snapshot times) as data variables, coordinates and attributes.
+    This convenient function creates a new xarray.Dataset object with model
+    input values, time steps and model output variables (including snapshot
+    times) as data variables, coordinates and attributes.
 
     Parameters
     ----------
@@ -612,7 +612,7 @@ def create_setup(model=None, input_vars=None, clocks=None, master_clock=None,
         it will be used as master clock.
     master_clock : str or dict, optional
         Name of the clock coordinate (dimension) that will be used as master
-        clock. A dictionary with at least a 'dim' key can also be provided.
+        clock. A dictionary with at least a 'dim' key can be provided instead.
         Time units and calendar (CF-conventions) can be set manually using
         'units' and 'calendar' keys, respectively.
     snapshot_vars : dict of dicts, optional

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -67,12 +67,11 @@ class SimlabAccessor(object):
                     return dim
             return None
 
-    @master_clock_dim.setter
-    def master_clock_dim(self, dim):
+    def _set_master_clock_dim(self, dim):
         if dim not in self._obj.coords:
             raise KeyError("Dataset has no %r dimension coordinate. "
                            "To create a new master clock dimension, "
-                           "use Dataset.xsimlab.set_master_clock instead."
+                           "use Dataset.xsimlab.update_clock."
                            % dim)
 
         if self.master_clock_dim is not None:
@@ -160,7 +159,7 @@ class SimlabAccessor(object):
         if calendar is not None:
             self._obj[dim].attrs['calendar'] = calendar
 
-        self.master_clock_dim = dim
+        self._set_master_clock_dim(dim)
 
     def set_snapshot_clock(self, dim, data=None, start=0., end=None,
                            step=None, nsteps=None, auto_adjust=True):

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -422,23 +422,24 @@ class SimlabAccessor(object):
     def update_clocks(self, model=None, clocks=None, master_clock=None):
         """Update clock coordinates.
 
-        Update the entire set of master and snapshot clock coordinates.
-        Snapshot-related attributes will be copied from existing coordinates, if
-        any.
+        Drop all clock coordinates (if any) and add a new set of master and
+        snapshot clock coordinates.
+        Also copy the snapshot-specific attributes of replaced coordinates
+        (i.e., coordinates with unchanged names).
 
         Parameters
         ----------
         model : Model object, optional
             Reference model.
         clocks : dict of dicts, optional
-            Used to create on or several clock coordinates. The structure of the
-            dict of dicts looks like {'dim': {kwarg: value, ...}, ...}.
+            Used to create one or several clock coordinates. The structure of
+            the dict of dicts looks like {'dim': {kwarg: value, ...}, ...}.
             See :meth:`xsimlab.create_setup` for more info.
         master_clock : str or dict, optional
             Name of the clock coordinate (dimension) that will be used as master
             clock. A dictionary with at least a 'dim' key can be provided
-            instead. Time units and calendar (CF-conventions) can be set
-            manually using 'units' and 'calendar' keys, respectively.
+            instead. Time units and calendar (CF-conventions) can also be set
+            using 'units' and 'calendar' keys, respectively.
 
         Returns
         -------
@@ -549,8 +550,8 @@ class SimlabAccessor(object):
 
         Keep only data variables and coordinates that correspond to inputs of
         the model (keep clock coordinates too). Also update snapshot-specific
-        attributes so that all included variable names correspond to variables
-        declared in the processes of the model.
+        attributes so that their values all correspond to processes and
+        variables defined in the model.
 
         Parameters
         ----------

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -45,7 +45,6 @@ class SimlabAccessor(object):
 
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
-        self._model = None
         self._master_clock_dim = None
 
     @property
@@ -241,40 +240,6 @@ class SimlabAccessor(object):
             attr_value = da_master_clock.attrs.get(attr_name)
             if attr_value is not None:
                 self._obj[dim].attrs[attr_name] = attr_value
-
-    def use_model(self, obj):
-        """Set a Model to use with this Dataset.
-
-        Parameters
-        ----------
-        obj : object
-            The `Model` instance to use.
-
-        Raises
-        ------
-        TypeError
-            If `obj` is not a Model object.
-
-        """
-        if not isinstance(obj, Model):
-            raise TypeError("%r is not a Model object" % obj)
-        self._model = obj
-
-    @property
-    def model(self):
-        """Model instance to use with this dataset (read-only).
-
-        See Also
-        --------
-        :meth:`xarray.Dataset.xsimlab.use_model`
-
-        """
-        return self._model
-
-    @model.setter
-    def model(self, value):
-        raise AttributeError("can't set 'model' attribute, "
-                             "use `Dataset.xsimlab.use_model` instead")
 
     def _set_input_vars(self, model, process, **inputs):
         """Set or add Dataset variables that correspond to model

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -26,6 +26,15 @@ def filter_accessor(dataset):
     return filter
 
 
+def _maybe_get_model_from_context(model):
+    """Return the given model or try to find it in the context if there was
+    none supplied.
+    """
+    if model is None:
+        return Model.get_context()
+    return model
+
+
 @register_dataset_accessor('xsimlab')
 class SimlabAccessor(object):
     """simlab extension to `xarray.Dataset`."""
@@ -441,12 +450,9 @@ class SimlabAccessor(object):
         :meth:`xsimlab.create_setup`
 
         """
-        if model is None:
-            # TODO: try get model ob ject from context
-            raise ValueError("no model provided")
+        model = _maybe_get_model_from_context(model)
 
         ds = self._obj.drop(self.clock_coords)
-        ds.xsimlab.use_model(model)
 
         attrs_master_clock = {}
 
@@ -519,12 +525,9 @@ class SimlabAccessor(object):
         :meth:`xsimlab.create_setup`
 
         """
-        if model is None:
-            # TODO: try get model object from context
-            raise ValueError("no model provided")
+        model = _maybe_get_model_from_context(model)
 
         ds = self._obj.copy()
-        ds.xsimlab.use_model(model)
 
         if input_vars is not None:
             for proc_name, vars in input_vars.items():
@@ -560,9 +563,7 @@ class SimlabAccessor(object):
         :meth:`Dataset.xsimlab.update_vars`
 
         """
-        if model is None:
-            # TODO: try get model object from context
-            raise ValueError("no model provided")
+        model = _maybe_get_model_from_context(model)
 
         drop_variables = []
 
@@ -578,7 +579,6 @@ class SimlabAccessor(object):
                 drop_variables.append(xr_var_name)
 
         ds = self._obj.drop(drop_variables)
-        ds.xsimlab.use_model(model)  # TODO: remove this
 
         for dim, var_list in self.snapshot_vars.items():
             var_dict = defaultdict(list)
@@ -606,10 +606,7 @@ class SimlabAccessor(object):
             Another Dataset with model inputs and outputs.
 
         """
-        if model is None:
-            if self._model is None:
-                raise ValueError("No model attached to this Dataset")
-            model = self._model
+        model = _maybe_get_model_from_context(model)
 
         if safe_mode:
             model = model.clone()
@@ -677,9 +674,7 @@ def create_setup(model=None, clocks=None, master_clock=None,
         A new Dataset object that may be used for running simulations.
 
     """
-    if model is None:
-        # TODO: try get model object from context
-        raise ValueError("no model provided")
+    model = _maybe_get_model_from_context(model)
 
     ds = (Dataset()
           .xsimlab.update_clocks(model=model, clocks=clocks,

--- a/xsimlab/xr_interface.py
+++ b/xsimlab/xr_interface.py
@@ -28,8 +28,8 @@ class DatasetModelInterface(object):
         self.model = model
         self.dataset = dataset
 
-        self.dim_master_clock = dataset.xsimlab.dim_master_clock
-        if self.dim_master_clock is None:
+        self.master_clock_dim = dataset.xsimlab.master_clock_dim
+        if self.master_clock_dim is None:
             raise ValueError("missing master clock dimension / coordinate ")
 
         self.check_model_inputs_in_dataset()
@@ -65,18 +65,18 @@ class DatasetModelInterface(object):
         dimension and those that don't.
         """
         ds_clock = self.dataset.filter(
-            lambda v: self.dim_master_clock in v.dims
+            lambda v: self.master_clock_dim in v.dims
         )
         ds_no_clock = self.dataset.filter(
-            lambda v: self.dim_master_clock not in v.dims
+            lambda v: self.master_clock_dim not in v.dims
         )
         return ds_clock, ds_no_clock
 
     @property
     def time_step_lengths(self):
         """Return a DataArray with time-step durations."""
-        clock_coord = self.dataset[self.dim_master_clock]
-        return clock_coord.diff(self.dim_master_clock).values
+        clock_coord = self.dataset[self.master_clock_dim]
+        return clock_coord.diff(self.master_clock_dim).values
 
     def init_snapshots(self):
         """Initialize snapshots for model variables given in attributes of
@@ -89,7 +89,7 @@ class DatasetModelInterface(object):
             self.snapshot_values.update({v: [] for v in vars})
 
         self.snapshot_save = {
-            clock: np.in1d(self.dataset[self.dim_master_clock].values,
+            clock: np.in1d(self.dataset[self.master_clock_dim].values,
                            self.dataset[clock].values)
             for clock in self.snapshot_vars if clock is not None
         }
@@ -184,7 +184,7 @@ class DatasetModelInterface(object):
 
         for istep, dt in enumerate(self.time_step_lengths):
             if ds_clock_any:
-                ds_step = ds_clock.isel(**{self.dim_master_clock: istep})
+                ds_step = ds_clock.isel(**{self.master_clock_dim: istep})
                 self.set_model_inputs(ds_step)
 
             self.model.run_step(dt)


### PR DESCRIPTION
API refactoring and improvements for `Dataset.xsimlab` accessor.

The basic idea is to avoid as much as possible methods that modify the Dataset in place and instead provide a small set of consistent methods that we can easily chain together. The integration of `xsimlab.Model` objects should also be improved (e.g., using a context manager).

Related to #2 and #4 

TODO:

- [x] create new `update_clocks` and `update_vars` methods
- [x] update create setup (don't add default values for missing processes anymore)
- [x] add a `filter_vars(model=None)` method that keeps in Dataset only variables (and 
  snapshot attributes) that are related to `model` 
- [x] change position of `input_vars` kwarg in `create_setup` (after `master_clock`)
- [x] `set_master_clock`, `set_snapshot_clock`, `set_input_vars` and `set_snapshot_vars`
   methods shouldn't be part of the public API anymore
- [x] `dim_master_clock` property should still be public but read_only (maybe rename it to `master_clock_dim` to be more consistent with `clock_coords`)
- [x] remove `_xsimlab_snapshot_clock` reserved attribute and use instead `_xsimlab_clock` (*)
- [x] implement a context manager for dealing with `Model` objects
- [x] add or update tests 
- [x] review and enhance docstrings
- [x] update example notebook in doc with the new API

(*) master clock can also be used for snapshots. master clock would then have both  `_xsimlab_clock` and `_xsimlab_master_clock` attributes. Implementation of `Dataset.xsimlab.clock_coords` is more straightforward too. 
 