### PR TITLE
Fix misinterpreted tuples passed as `allowed_dims` for `Variable`

### DIFF
--- a/xsimlab/tests/conftest.py
+++ b/xsimlab/tests/conftest.py
@@ -20,7 +20,7 @@ class ExampleProcess(Process):
     """A full example of process interface.
     """
     var = Variable((), provided=True)
-    var_list = VariableList([Variable('x'), Variable(((), 'x'))])
+    var_list = VariableList([Variable('x'), Variable([(), 'x'])])
     var_group = VariableGroup('group')
     no_var = 'this is not a variable object'
 

--- a/xsimlab/tests/test_variable.py
+++ b/xsimlab/tests/test_variable.py
@@ -23,8 +23,11 @@ class TestVariable(object):
             var = Variable(allowed_dims)
             assert var.allowed_dims == (('x',),)
 
+        var = Variable(('x', 'y'))
+        assert var.allowed_dims == (('x', 'y'),)
+
         var = Variable([(), 'x', ('x', 'y')])
-        assert var.allowed_dims, ((), ('x',), ('x', 'y'))
+        assert var.allowed_dims == ((), ('x',), ('x', 'y'))
 
     def test_validators(self):
         # verify default validators + user supplied validators

--- a/xsimlab/tests/test_variable.py
+++ b/xsimlab/tests/test_variable.py
@@ -19,7 +19,7 @@ class TestVariable(object):
             var = Variable(allowed_dims)
             assert var.allowed_dims == ((),)
 
-        for allowed_dims in ('x', ['x'], tuple(['x'])):
+        for allowed_dims in ('x', ['x'], ('x')):
             var = Variable(allowed_dims)
             assert var.allowed_dims == (('x',),)
 
@@ -77,7 +77,7 @@ class TestVariable(object):
         xr.testing.assert_identical(xr_var, expected_xr_var)
 
     def test_repr(self):
-        var = Variable(((), 'x', ('x', 'y')))
+        var = Variable([(), 'x', ('x', 'y')])
         expected_repr = "<xsimlab.Variable (), ('x'), ('x', 'y')>"
         assert repr(var) == expected_repr
 

--- a/xsimlab/variable/base.py
+++ b/xsimlab/variable/base.py
@@ -96,12 +96,12 @@ class Variable(AbstractVariable):
 
         if not len(allowed_dims):
             allowed_dims = [()]
-        if isinstance(allowed_dims, str):
+        elif isinstance(allowed_dims, str):
             allowed_dims = [(allowed_dims,)]
         elif isinstance(allowed_dims, list):
             allowed_dims = [tuple([d]) if isinstance(d, str) else tuple(d)
                             for d in allowed_dims]
-        elif len(allowed_dims) == 1:
+        else:
             allowed_dims = [allowed_dims]
         self.allowed_dims = tuple(allowed_dims)
 


### PR DESCRIPTION
length >1 tuples were not interpreted correctly.