### PR TITLE
Better error messages when model object is missing or not a model object

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,8 @@ Bug fixes
 
 - Fix misinterpreted tuples passed as ``allowed_dims`` argument of
   ``Variable`` init (:issue:`17`).
+- Better error message when a Model instance is expected but no object
+  is found or a different object is provided (:issue:`13`).
 
 v0.1.0 (8 October 2017)
 -----------------------

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -31,7 +31,14 @@ def _maybe_get_model_from_context(model):
     none supplied.
     """
     if model is None:
-        return Model.get_context()
+        try:
+            return Model.get_context()
+        except TypeError:
+            raise TypeError("no model found in context")
+
+    if not isinstance(model, Model):
+        raise TypeError("%s is not an instance of xsimlab.Model" % model)
+
     return model
 
 


### PR DESCRIPTION
Closes #13 and #14.