### PR TITLE
Include parent classes in process name/class reverse lookup

### DIFF
--- a/doc/create_model.rst
+++ b/doc/create_model.rst
@@ -291,3 +291,52 @@ In this latter case, users will have to provide initial values of
    possible to modify these instances by adding, updating or removing
    processes. Both methods ``.update_processes()`` and
    ``.drop_processes()`` always return new instances of ``Model``.
+
+Customize existing processes
+----------------------------
+
+Sometimes we only want to update an existing model with very minor
+changes.
+
+As an example, let's update ``model2`` by using a fixed grid (i.e.,
+with hard-coded values for grid spacing and length). One way to
+achieve this is to create a small new process class that sets
+the values of ``spacing`` and ``length``:
+
+.. literalinclude:: scripts/advection_model.py
+   :lines: 151-158
+
+However, one drawback of this "additive" approach is that the number
+of processes in a model might become unnecessarily high:
+
+.. literalinclude:: scripts/advection_model.py
+   :lines: 161-161
+
+Alternatively, it is possible to write a process class that inherits
+from ``UniformGrid1D``, in which we can re-declare variables *and/or*
+re-define "runtime" methods:
+
+.. literalinclude:: scripts/advection_model.py
+   :lines: 164-172
+
+We can here directly update the model and replace the original process
+``UniformGrid1D`` by the inherited class ``FixedGrid``. Foreign
+variables that refer to ``UniformGrid1D`` will still correctly point
+to the ``grid`` process in the updated model:
+
+.. literalinclude:: scripts/advection_model.py
+   :lines: 175-175
+
+.. warning::
+
+   This feature is experimental! It may be removed in a next version of
+   xarray-simlab.
+
+   In particular, linking foreign variables in a model is ambiguous
+   when both conditions below are met:
+
+   - two different processes in a model inherit from a common class
+     (except ``object``)
+
+   - a third process in the same model has a foreign variable that
+     links to that common class

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -5,8 +5,8 @@ channels:
 dependencies:
   - attrs=19.1.0
   - python=3.7
-  - numpy=1.16.0
-  - pandas=0.23.3
+  - numpy=1.17.2
+  - pandas=0.25.1
   - xarray=0.13.0
   - ipython=7.8.0
   - matplotlib=3.0.2

--- a/doc/scripts/advection_model.py
+++ b/doc/scripts/advection_model.py
@@ -146,3 +146,30 @@ model3 = model2.update_processes({'source': SourcePoint,
 
 
 model4 = model2.drop_processes('init')
+
+
+@xs.process
+class FixedGridParams(object):
+    spacing = xs.foreign(UniformGrid1D, 'spacing', intent='out')
+    length = xs.foreign(UniformGrid1D, 'length', intent='out')
+
+    def initialize(self):
+        self.spacing = 0.01
+        self.length = 1.
+
+
+model5 = model2.update_processes({'fixed_grid_params': FixedGridParams})
+
+
+@xs.process
+class FixedGrid(UniformGrid1D):
+    spacing = xs.variable(description='uniform spacing', intent='out')
+    length = xs.variable(description='total length', intent='out')
+
+    def initialize(self):
+        self.spacing = 0.01
+        self.length = 1.
+        super(FixedGrid, self).initialize()
+
+
+model6 = model2.update_processes({'grid': FixedGrid})

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,6 +6,16 @@ Release Notes
 v0.3.0 (Unreleased)
 -------------------
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+- It is now possible to use class inheritance to customize a process
+  without re-writing the class from scratch and without breaking the
+  links between (foreign) variables when replacing the process in a
+  model (:issue:`45`). Although it should work just fine in most
+  cases, there are potential caveats. This should be considered as an
+  experimental, possibly breaking change.
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/xsimlab/tests/test_model.py
+++ b/xsimlab/tests/test_model.py
@@ -1,7 +1,7 @@
 import pytest
 
 import xsimlab as xs
-from xsimlab.tests.fixture_model import AddOnDemand, InitProfile
+from xsimlab.tests.fixture_model import AddOnDemand, InitProfile, Profile
 
 
 class TestModelBuilder(object):
@@ -99,6 +99,22 @@ class TestModelBuilder(object):
     def test_get_stage_processes(self, model):
         expected = [model['roll'], model['profile']]
         assert model._p_run_step == expected
+
+    def test_process_inheritance(self, model):
+        @xs.process
+        class InheritedProfile(Profile):
+            pass
+
+        new_model = model.update_processes(
+            {'profile': InheritedProfile})
+
+        assert type(new_model['profile']) is InheritedProfile
+        assert isinstance(new_model['profile'], Profile)
+
+        with pytest.raises(ValueError) as excinfo:
+            invalid_model = model.update_processes(
+                {'profile2': InheritedProfile})
+        assert "multiple processes" in str(excinfo.value)
 
 
 class TestModel(object):


### PR DESCRIPTION
- Closes #24
- [x] add tests
- [x] update doc
- [x] add release notes

A possible way to customize processes is to use class inheritance. However, a current limitation is that foreign variables hard-code external classes, making it difficult to customize a model by replacing a process class by one of its sub-classes.

This PR address this issue by also including parent classes in the process name/class reverse lookup that is used to link foreign variables to their corresponding process when building a new model. Using the example in the docs, it is now possible to do something like:

```python
@xs.process
class AlternativeGrid1D(UniformGrid1D):
    """Give number of nodes instead of total length as input."""

    spacing = xs.variable(description='uniform spacing')
    nnodes = xs.variable(description='number of nodes')
    
    length = xs.variable(intent='out')
    x = xs.variable(dims='x', intent='out')

    def initialize(self):
        self.length = (self.nnodes - 1) * self.spacing
        super(AlternativeGrid1D, self).initialize()


# no error "Process class 'UniformGrid1D' missing in Model"
alt_model = model2.update_processes({'grid': AlternativeGrid1D})
```

In the example above, the foreign variables declared in other processes of `alt_model` are now correctly linked to the `'grid'` process even if they were declared like ``xs.foreign(UniformGrid1D, 'x')``, as `AlternativeGrid1D` inherits from `UniformGrid1D`.

One drawback (and possible breaking change) is that linking foreign variables is ambiguous when both conditions below are met:

- two different processes in a model have a common class in their MRO (except `object`)
- a third process have a foreign variable that links to that specific class

For example:

```python
 # this gives an error
alt_model = xs.Model({'grid': UniformGrid1D,
                      'grid2': AlternativeGrid1D,
                      'profile': ProfileU,
                      'init': InitUGauss,   # does init.x refers to grid.x or grid2.x?
                      'advect': AdvectionLax})
```

While the example above doesn't make any sense, I can't think about a real case where this should happen.

This feature is quite robust IMO, but it should be considered as experimental.