### PR TITLE
Fix _CountingAttr hack with attrs master

### DIFF
--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -21,7 +21,31 @@ class VarIntent(Enum):
 class _CountingAttr(CountingAttr_):
     """A hack to add a custom 'compute' decorator for on-request computation
     of on_demand variables.
+
+    Hope there will be a chance to have a cleaner solution,
+    see https://github.com/python-attrs/attrs/issues/340.
     """
+    def __init__(self, metadata):
+        # reduce the risk of breaking the code when argument list of
+        # CountingAttr changes (assumes attr.attrib have similar arg list)
+        attrib_args = dict(zip(attr.attrib.__code__.co_varnames,
+                               attr.attrib.__defaults__))
+        attrib_args.update({
+            'default': attr.NOTHING,
+            'validator': None,
+            'repr': False,
+            'cmp': False,
+            'hash': None,
+            'init': False,
+            'converter': None,
+            'metadata': metadata,
+            'type': None
+        })
+
+        init_arg_names = CountingAttr_.__init__.__code__.co_varnames[1:]
+        args = [attrib_args[k] for k in init_arg_names]
+
+        super(_CountingAttr, self).__init__(*args)
 
     def compute(self, method):
         self.metadata['compute'] = method
@@ -180,17 +204,7 @@ def on_demand(dims=(), group=None, description='', attrs=None):
                 'attrs': attrs or {},
                 'description': description}
 
-    return _CountingAttr(
-        default=attr.NOTHING,
-        validator=None,
-        repr=False,
-        cmp=False,
-        hash=None,
-        init=False,
-        converter=None,
-        metadata=metadata,
-        type=None,
-    )
+    return _CountingAttr(metadata)
 
 
 def foreign(other_process_cls, var_name, intent='in'):


### PR DESCRIPTION
A workaround before (hopefully) a cleaner solution (see https://github.com/python-attrs/attrs/issues/340).

Re-use argument list from `attr.attrib` for `_CountingAttr.__init__()`. It should at least reduce the risk of breaking the code when new arguments are introduced.