### PR TITLE
Ensure no variable intent conflict when building a model

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,6 +6,13 @@ Release Notes
 v0.3.0 (Unreleased)
 -------------------
 
+Enhancements
+~~~~~~~~~~~~
+
+- Ensure that there is no ``intent`` conflict between the variables
+  declared in a model. This check is explicit at Model creation and a
+  more meaningful error message is shown when it fails (:issue:`57`).
+
 
 v0.2.1 (7 November 2018)
 ------------------------

--- a/xsimlab/tests/test_model.py
+++ b/xsimlab/tests/test_model.py
@@ -1,7 +1,7 @@
 import pytest
 
 import xsimlab as xs
-from xsimlab.tests.fixture_model import AddOnDemand, InitProfile
+from xsimlab.tests.fixture_model import AddOnDemand, InitProfile, Profile
 
 
 class TestModelBuilder(object):

--- a/xsimlab/tests/test_model.py
+++ b/xsimlab/tests/test_model.py
@@ -52,6 +52,15 @@ class TestModelBuilder(object):
         assert all([p_name in model for p_name, _ in model.all_vars])
         assert ('profile', 'u') in model.all_vars
 
+    def test_ensure_no_intent_conflict(self, model):
+        @xs.process
+        class Foo(object):
+            u = xs.foreign(Profile, 'u', intent='out')
+
+        with pytest.raises(ValueError) as excinfo:
+            invalid_model = model.update_processes({'foo': Foo})
+        assert "Conflict(s)" in str(excinfo.value)
+
     def test_get_input_variables(self, model):
         expected = {('init_profile', 'n_points'),
                     ('roll', 'shift'),


### PR DESCRIPTION
This was not explicitly checked. Now there will be a more meaningful error message. Also added tests. 