### PR TITLE
Refactor process execution during a simulation

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -104,10 +104,7 @@ interfaces.
 .. autosummary::
    :toctree: _api_generated/
 
-   Model.initialize
-   Model.run_step
-   Model.finalize_step
-   Model.finalize
+   Model.execute
 
 Process
 =======

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -127,6 +127,14 @@ Process introspection and variables
    variable_info
    filter_variables
 
+Process runtime methods
+-----------------------
+
+.. autosummary::
+   :toctree: _api_generated/
+
+   runtime
+
 Variable
 ========
 

--- a/doc/create_model.rst
+++ b/doc/create_model.rst
@@ -94,9 +94,8 @@ methods that will be called during simulation runtime:
   simulation. Here it is used to set the x-coordinate values of the
   grid and the initial values of ``u`` along the grid (Gaussian
   pulse).
-- ``.run_step()`` will be called at each time step iteration and have
-  the current time step duration as required argument. This is where
-  the Lax method is implemented.
+- ``.run_step()`` will be called at each time step iteration. This is
+  where the Lax method is implemented.
 - ``.finalize_step()`` will be called at each time step iteration too
   but after having called ``run_step`` for all other processes (if
   any). Its intended use is mainly to ensure that state variables like

--- a/doc/create_model.rst
+++ b/doc/create_model.rst
@@ -47,7 +47,7 @@ Let's first wrap the code above into a single class named
 explain in detail the content of this class.
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 3-32
+   :lines: 3-33
 
 Process interface
 ~~~~~~~~~~~~~~~~~
@@ -133,7 +133,7 @@ need to provide a dictionary with the process class(es) that we want
 to include in the model, e.g., with only the process created above:
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 35
+   :lines: 36
 
 That's it! Now we have different tools already available to inspect
 the model (see section :doc:`inspect_model`). We can also use that
@@ -168,7 +168,7 @@ This process declares all grid-related variables and computes
 x-coordinate values.
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 38-47
+   :lines: 39-48
 
 Grid x-coordinate values only need to be set once at the beginning of
 the simulation ; there is no need to implement ``.run_step()`` here.
@@ -176,7 +176,7 @@ the simulation ; there is no need to implement ``.run_step()`` here.
 **ProfileU**
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 50-62
+   :lines: 51-63
 
 ``u_vars`` is declared as a :func:`~xsimlab.group` variable, i.e., an
 iterable of all variables declared elsewhere that belong the same
@@ -191,7 +191,7 @@ value from elsewhere.
 **AdvectionLax**
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 65-83
+   :lines: 66-85
 
 ``u_advected`` represents the effect of advection on the evolution of
 :math:`u` and therefore belongs to the group 'u_vars'.
@@ -207,7 +207,7 @@ handle them like if these were the original variables. For example,
 **InitUGauss**
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 86-96
+   :lines: 88-98
 
 A foreign variable can also be used to set values for variables that
 are declared in other processes, as for ``u`` here with
@@ -218,7 +218,7 @@ are declared in other processes, as for ``u`` here with
 We now have all the building blocks to create a more flexible model:
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 99-102
+   :lines: 101-104
 
 The order in which processes are given doesn't matter (it is a
 dictionary). A computationally consistent order, as well as model
@@ -243,7 +243,7 @@ original, simple version.
 For this we create a new process:
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 105-130
+   :lines: 107-133
 
 Some comments about this class:
 
@@ -263,13 +263,13 @@ profile instead of a Gaussian pulse. We create another (minimal)
 process for that:
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 133-141
+   :lines: 136-144
 
 Using one command, we can then update the model with these new
 features:
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 144-145
+   :lines: 147-148
 
 Compared to ``model2``, this new ``model3`` have a new process named
 'source' and a replaced process 'init'.
@@ -280,7 +280,7 @@ It is also possible to create new models by removing one or more
 processes from existing Model instances, e.g.,
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 148
+   :lines: 151
 
 In this latter case, users will have to provide initial values of
 :math:`u` along the grid directly as an input array.
@@ -304,20 +304,20 @@ achieve this is to create a small new process class that sets
 the values of ``spacing`` and ``length``:
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 151-158
+   :lines: 154-161
 
 However, one drawback of this "additive" approach is that the number
 of processes in a model might become unnecessarily high:
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 161-161
+   :lines: 164
 
 Alternatively, it is possible to write a process class that inherits
 from ``UniformGrid1D``, in which we can re-declare variables *and/or*
 re-define "runtime" methods:
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 164-172
+   :lines: 167-175
 
 We can here directly update the model and replace the original process
 ``UniformGrid1D`` by the inherited class ``FixedGrid``. Foreign
@@ -325,7 +325,7 @@ variables that refer to ``UniformGrid1D`` will still correctly point
 to the ``grid`` process in the updated model:
 
 .. literalinclude:: scripts/advection_model.py
-   :lines: 175-175
+   :lines: 178
 
 .. warning::
 

--- a/doc/create_model.rst
+++ b/doc/create_model.rst
@@ -106,6 +106,12 @@ A fourth method ``.finalize()`` could also be implemented, but it is
 not needed in this case. This method is called once at the end of the
 simulation, e.g., for some clean-up.
 
+Each of these methods can be decorated with :func:`~xsimlab.runtime`
+to pass some useful information during simulation runtime (e.g.,
+current time step number, current time or time step duration), which
+may be need for the computation. Without this decorator, runtime
+methods must have no other parameter than ``self``.
+
 Getting / setting variable values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/scripts/advection_model.py
+++ b/doc/scripts/advection_model.py
@@ -22,6 +22,7 @@ class AdvectionLax1D:
         self.x = np.arange(0, self.length, self.spacing)
         self.u = np.exp(-1 / self.scale**2 * (self.x - self.loc)**2)
 
+    @xs.runtime(args='dt')
     def run_step(self, dt):
         factor = (self.v * dt) / (2 * self.spacing)
         u_left = np.roll(self.u, 1)
@@ -55,7 +56,7 @@ class ProfileU:
     u = xs.variable(dims='x', intent='inout', description='quantity u',
                     attrs={'units': 'm'})
 
-    def run_step(self, *args):
+    def run_step(self):
         self._delta_u = sum((v for v in self.u_vars))
 
     def finalize_step(self):
@@ -73,6 +74,7 @@ class AdvectionLax:
     u = xs.foreign(ProfileU, 'u')
     u_advected = xs.variable(dims='x', intent='out', group='u_vars')
 
+    @xs.runtime(args='dt')
     def run_step(self, dt):
         factor = self.v / (2 * self.grid_spacing)
 
@@ -126,6 +128,7 @@ class SourcePoint:
         src_array[self.nearest_node] = self.flux
         return src_array
 
+    @xs.runtime(args='dt')
     def run_step(self, dt):
         self.u_source = self.source_rate * dt
 

--- a/doc/scripts/advection_model.py
+++ b/doc/scripts/advection_model.py
@@ -22,7 +22,7 @@ class AdvectionLax1D:
         self.x = np.arange(0, self.length, self.spacing)
         self.u = np.exp(-1 / self.scale**2 * (self.x - self.loc)**2)
 
-    @xs.runtime(args='step_duration')
+    @xs.runtime(args='step_delta')
     def run_step(self, dt):
         factor = (self.v * dt) / (2 * self.spacing)
         u_left = np.roll(self.u, 1)
@@ -74,7 +74,7 @@ class AdvectionLax:
     u = xs.foreign(ProfileU, 'u')
     u_advected = xs.variable(dims='x', intent='out', group='u_vars')
 
-    @xs.runtime(args='step_duration')
+    @xs.runtime(args='step_delta')
     def run_step(self, dt):
         factor = self.v / (2 * self.grid_spacing)
 
@@ -128,7 +128,7 @@ class SourcePoint:
         src_array[self.nearest_node] = self.flux
         return src_array
 
-    @xs.runtime(args='step_duration')
+    @xs.runtime(args='step_delta')
     def run_step(self, dt):
         self.u_source = self.source_rate * dt
 

--- a/doc/scripts/advection_model.py
+++ b/doc/scripts/advection_model.py
@@ -22,7 +22,7 @@ class AdvectionLax1D:
         self.x = np.arange(0, self.length, self.spacing)
         self.u = np.exp(-1 / self.scale**2 * (self.x - self.loc)**2)
 
-    @xs.runtime(args='dt')
+    @xs.runtime(args='step_duration')
     def run_step(self, dt):
         factor = (self.v * dt) / (2 * self.spacing)
         u_left = np.roll(self.u, 1)
@@ -74,7 +74,7 @@ class AdvectionLax:
     u = xs.foreign(ProfileU, 'u')
     u_advected = xs.variable(dims='x', intent='out', group='u_vars')
 
-    @xs.runtime(args='dt')
+    @xs.runtime(args='step_duration')
     def run_step(self, dt):
         factor = self.v / (2 * self.grid_spacing)
 
@@ -128,7 +128,7 @@ class SourcePoint:
         src_array[self.nearest_node] = self.flux
         return src_array
 
-    @xs.runtime(args='dt')
+    @xs.runtime(args='step_duration')
     def run_step(self, dt):
         self.u_source = self.source_rate * dt
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,6 +15,17 @@ Breaking changes
   model (:issue:`45`). Although it should work just fine in most
   cases, there are potential caveats. This should be considered as an
   experimental, possibly breaking change.
+- ``Model.initialize``, ``Model.run_step``, ``Model.finalize_step``
+  and ``Model.finalize`` have been removed in favor of
+  ``Model.execute`` (:issue:`59`).
+
+Deprecations
+~~~~~~~~~~~~
+
+- ``run_step`` methods defined in process classes won't accept anymore
+  current step duration as a positional argument by default. Use the
+  ``runtime`` decorator if you need current step duration (and/or
+  other runtime information) inside the method (:issue:`59`).
 
 Enhancements
 ~~~~~~~~~~~~
@@ -22,7 +33,8 @@ Enhancements
 - Ensure that there is no ``intent`` conflict between the variables
   declared in a model. This check is explicit at Model creation and a
   more meaningful error message is shown when it fails (:issue:`57`).
-
+- Added ``runtime`` decorator to pass simulation runtime information
+  to the (runtime) methods defined in process classes (:issue:`59`).
 
 v0.2.1 (7 November 2018)
 ------------------------

--- a/xsimlab/__init__.py
+++ b/xsimlab/__init__.py
@@ -4,7 +4,8 @@ xarray-simlab.
 """
 from .xr_accessor import SimlabAccessor, create_setup
 from .variable import variable, on_demand, foreign, group
-from .process import filter_variables, process, process_info, variable_info
+from .process import (filter_variables, process, process_info, runtime,
+                      variable_info)
 from .model import Model
 
 from ._version import get_versions

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -15,7 +15,7 @@ class RuntimeContext(Mapping):
                      'step',
                      'step_start',
                      'step_end',
-                     'step_duration')
+                     'step_delta')
 
     def __init__(self, **kwargs):
         self._context = {k: 0 for k in self._context_keys}
@@ -312,7 +312,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
             runtime_context.update(step=step,
                                    step_start=ds_step['_clock_start'].values,
                                    step_end=ds_step['_clock_end'].values,
-                                   step_duration=ds_step['_clock_diff'].values)
+                                   step_delta=ds_step['_clock_diff'].values)
 
             self._set_input_vars(ds_step)
 

--- a/xsimlab/formatting.py
+++ b/xsimlab/formatting.py
@@ -120,11 +120,8 @@ def repr_process(process):
     if not var_section_details:
         var_section_details = "    *empty*"
 
-    stages_implemented = [
-        "    {}".format(m)
-        for m in ['initialize', 'run_step', 'finalize_step', 'finalize']
-        if has_method(process, m)
-    ]
+    stages_implemented = ["    {}".format(s)
+                          for s in process.__xsimlab_executor__.stages]
 
     stages_section_summary = "Simulation stages:"
     if stages_implemented:

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -3,7 +3,7 @@ from inspect import isclass
 
 from .variable import VarIntent, VarType
 from .process import (ensure_process_decorated, filter_variables,
-                      get_target_variable)
+                      get_target_variable, SimulationStage)
 from .utils import AttrMapping, ContextMixin, has_method, variables_dict
 from .formatting import repr_model
 
@@ -365,15 +365,6 @@ class _ModelBuilder:
         )
         return self._sorted_processes
 
-    def get_stage_processes(self, stage):
-        """Return a (sorted) list of all process objects that implement the
-        method relative to a given simulation stage {'initialize', 'run_step',
-        'finalize_step', 'finalize'}.
-
-        """
-        return [p_obj for p_obj in self._sorted_processes.values()
-                if has_method(p_obj, stage)]
-
 
 class Model(AttrMapping, ContextMixin):
     """An immutable collection of process units that together form a
@@ -428,11 +419,6 @@ class Model(AttrMapping, ContextMixin):
 
         self._dep_processes = builder.get_process_dependencies()
         self._processes = builder.get_sorted_processes()
-
-        self._p_initialize = builder.get_stage_processes('initialize')
-        self._p_run_step = builder.get_stage_processes('run_step')
-        self._p_finalize_step = builder.get_stage_processes('finalize_step')
-        self._p_finalize = builder.get_stage_processes('finalize')
 
         super(Model, self).__init__(self._processes)
         self._initialized = True
@@ -526,25 +512,39 @@ class Model(AttrMapping, ContextMixin):
                          show_inputs=show_inputs,
                          show_variables=show_variables)
 
+    def execute(self, stage, runtime_context):
+        """Run one stage of a simulation.
+
+        This shouldn't be called directly, except for debugging purpose.
+
+        Parameters
+        ----------
+        stage : str
+            Name of the simulation stage.
+        runtime_context : dict
+            Dictionary containing runtime variables (e.g., time step
+            duration, current step).
+
+        """
+        for p_obj in self._processes.values():
+            executor = p_obj.__xsimlab_executor__
+            executor.execute(p_obj, SimulationStage(stage), runtime_context)
+
     def initialize(self):
         """Run the 'initialize' stage of a simulation."""
-        for p in self._p_initialize:
-            p.initialize()
+        self.execute('initialize', {})
 
     def run_step(self, step):
         """Run a single 'run_step()' stage of a simulation."""
-        for p in self._p_run_step:
-            p.run_step(step)
+        self.execute('run_step', {'dt': step})
 
     def finalize_step(self):
         """Run a single 'finalize_step' stage of a simulation."""
-        for p in self._p_finalize_step:
-            p.finalize_step()
+        self.execute('finalize_step', {})
 
     def finalize(self):
         """Run the 'finalize' stage of a simulation."""
-        for p in self._p_finalize:
-            p.finalize()
+        self.execute('finalize', {})
 
     def clone(self):
         """Clone the Model, i.e., create a new Model instance with the same

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -530,22 +530,6 @@ class Model(AttrMapping, ContextMixin):
             executor = p_obj.__xsimlab_executor__
             executor.execute(p_obj, SimulationStage(stage), runtime_context)
 
-    def initialize(self):
-        """Run the 'initialize' stage of a simulation."""
-        self.execute('initialize', {})
-
-    def run_step(self, step):
-        """Run a single 'run_step()' stage of a simulation."""
-        self.execute('run_step', {'dt': step})
-
-    def finalize_step(self):
-        """Run a single 'finalize_step' stage of a simulation."""
-        self.execute('finalize_step', {})
-
-    def finalize(self):
-        """Run the 'finalize' stage of a simulation."""
-        self.execute('finalize', {})
-
     def clone(self):
         """Clone the Model, i.e., create a new Model instance with the same
         process classes but different instances.

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -310,7 +310,7 @@ def runtime(meth=None, args=None):
     meth : callable, optional
         The method to wrap (leave it to None if you use this function
         as a decorator).
-    args : string or list or tuple, optional
+    args : str or list or tuple, optional
         Variable(s) (e.g., time step duration, current step) that will
         be passed as positional arguments of the method during
         simulation runtime.

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -312,15 +312,22 @@ def runtime(meth=None, args=None):
         The method to wrap (leave it to None if you use this function
         as a decorator).
     args : str or list or tuple, optional
-        Variable(s) (e.g., time step duration, current step) that will
-        be passed as positional arguments of the method during
-        simulation runtime.
+        One or several labels of values that will be passed as
+        positional argument(s) of the method during simulation runtime.
+        The following labels are defined:
+
+        - ``sim_start`` : simulation start (date)time
+        - ``sim_end`` : simulation end (date)time
+        - ``step`` : current step number
+        - ``step_start`` : current step start (date)time
+        - ``step_end``: current step end (date)time
+        - ``step_duration``: current step duration
 
     Returns
     -------
     runtime_method
-       The same method that can be properly called during simulation
-       runtime.
+       The same method that can be called during a simulation
+       with runtime data.
 
     """
     def wrapper(func):

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -373,7 +373,7 @@ class _ProcessExecutor:
                                   "xarray-simlab. Use the `@runtime` "
                                   "decorator.",
                                   FutureWarning)
-                    args = ['dt']
+                    args = ['step_delta']
 
                 elif nparams > 1:
                     raise TypeError("Process runtime methods with positional "

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from enum import Enum
 import inspect
 import sys
@@ -345,7 +346,7 @@ class _ProcessExecutor:
     def __init__(self, cls):
         self.cls = cls
 
-        self.runtime_methods = {}
+        self.runtime_methods = OrderedDict()
 
         for stage in SimulationStage:
             if not has_method(self.cls, stage.value):

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -321,7 +321,7 @@ def runtime(meth=None, args=None):
         - ``step`` : current step number
         - ``step_start`` : current step start (date)time
         - ``step_end``: current step end (date)time
-        - ``step_duration``: current step duration
+        - ``step_delta``: current step duration
 
     Returns
     -------

--- a/xsimlab/tests/fixture_model.py
+++ b/xsimlab/tests/fixture_model.py
@@ -59,7 +59,7 @@ class Add:
                                       'to profile u'))
     u_diff = xs.variable(group='diff', intent='out')
 
-    @xs.runtime(args='invalid')
+    @xs.runtime(args='step_duration')
     def run_step(self, dt):
         self.u_diff = self.offset * dt
 
@@ -137,13 +137,13 @@ def in_dataset():
 
 @pytest.fixture
 def out_dataset(in_dataset):
-    out_ds = in_dataset
+    out_ds = in_dataset.copy()
 
     del out_ds.attrs[SimlabAccessor._output_vars_key]
     del out_ds.clock.attrs[SimlabAccessor._output_vars_key]
     del out_ds.out.attrs[SimlabAccessor._output_vars_key]
     out_ds['profile__u_opp'] = ('x', [-10., -10., -10., -10., -11.])
-    out_ds['profile_u'] = (
+    out_ds['profile__u'] = (
         ('clock', 'x'),
         np.array([[1., 0., 0., 0., 0.],
                   [1., 2., 1., 1., 1.],
@@ -152,7 +152,7 @@ def out_dataset(in_dataset):
                   [10., 10., 10., 10., 11.]]),
         {'description': 'quantity u'}
     )
-    out_ds['roll_u_diff'] = (
+    out_ds['roll__u_diff'] = (
         ('out', 'x'),
         np.array([[-1., 1., 0., 0., 0.],
                   [0., 0., -1., 1., 0.],

--- a/xsimlab/tests/fixture_model.py
+++ b/xsimlab/tests/fixture_model.py
@@ -18,7 +18,7 @@ class Profile:
     def initialize(self):
         self.u_change = np.zeros_like(self.u)
 
-    def run_step(self, *args):
+    def run_step(self):
         self.u_change[:] = sum((d for d in self.u_diffs))
 
     def finalize_step(self):
@@ -49,7 +49,7 @@ class Roll:
     u = xs.foreign(Profile, 'u')
     u_diff = xs.variable(dims='x', group='diff', intent='out')
 
-    def run_step(self, *args):
+    def run_step(self):
         self.u_diff = np.roll(self.u, self.shift) - self.u
 
 
@@ -59,6 +59,7 @@ class Add:
                                       'to profile u'))
     u_diff = xs.variable(group='diff', intent='out')
 
+    @xs.runtime(args='dt')
     def run_step(self, dt):
         self.u_diff = self.offset * dt
 

--- a/xsimlab/tests/fixture_model.py
+++ b/xsimlab/tests/fixture_model.py
@@ -59,7 +59,7 @@ class Add:
                                       'to profile u'))
     u_diff = xs.variable(group='diff', intent='out')
 
-    @xs.runtime(args='dt')
+    @xs.runtime(args='invalid')
     def run_step(self, dt):
         self.u_diff = self.offset * dt
 

--- a/xsimlab/tests/fixture_model.py
+++ b/xsimlab/tests/fixture_model.py
@@ -59,7 +59,7 @@ class Add:
                                       'to profile u'))
     u_diff = xs.variable(group='diff', intent='out')
 
-    @xs.runtime(args='step_duration')
+    @xs.runtime(args='step_delta')
     def run_step(self, dt):
         self.u_diff = self.offset * dt
 

--- a/xsimlab/tests/test_drivers.py
+++ b/xsimlab/tests/test_drivers.py
@@ -87,15 +87,6 @@ class TestXarraySimulationDriver:
         for k in expected:
             assert_array_equal(xarray_driver.output_save_steps[k], expected[k])
 
-    def test_time_step_lengths(self, xarray_driver):
-        assert_array_equal(xarray_driver._get_time_steps(), [2, 2, 2, 2])
-
-    def test_split_data_vars_clock(self, xarray_driver):
-        ds_in, ds_in_clock = xarray_driver._split_clock_inputs()
-
-        assert 'add__offset' in ds_in_clock and 'add__offset' not in ds_in
-        assert 'roll__shift' in ds_in and 'roll__shift' not in ds_in_clock
-
     @pytest.mark.parametrize('var_key,is_scalar', [
         (('init_profile', 'n_points'), True),
         (('add', 'offset'), False)

--- a/xsimlab/tests/test_model.py
+++ b/xsimlab/tests/test_model.py
@@ -105,10 +105,6 @@ class TestModelBuilder:
             xs.Model({'foo': Foo, 'bar': Bar})
         assert "Cycle detected" in str(excinfo.value)
 
-    def test_get_stage_processes(self, model):
-        expected = [model['roll'], model['profile']]
-        assert model._p_run_step == expected
-
     def test_process_inheritance(self, model):
         @xs.process
         class InheritedProfile(Profile):

--- a/xsimlab/utils.py
+++ b/xsimlab/utils.py
@@ -21,8 +21,8 @@ def variables_dict(process_cls):
                        if 'var_type' in v.metadata)
 
 
-def has_method(obj, meth):
-    return callable(getattr(obj, meth, False))
+def has_method(obj_or_cls, meth):
+    return callable(getattr(obj_or_cls, meth, False))
 
 
 def maybe_to_list(obj):


### PR DESCRIPTION
Closes #40.

Also provides more flexibility for #52.

This refactoring is also a step towards making the framework less invasive. Ideally, a process class could be also instantiated and used independently of any model. This is important for testing purposes! Currently it is supported for "runtime" methods but we need a solution for ``__init__`` too.

TODO:

- [x] set runtime context dictionary and use it in xarray driver
- [x] remove `Model.initialize()`, `Model.run_step()` etc (no depreciation)
- [x] add tests where it is needed
- [x] update docs
- [x] update what's new
