### PR TITLE
Decouple process class from Model

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,6 +35,7 @@ Documentation index
 * :doc:`create_model`
 * :doc:`inspect_model`
 * :doc:`run_model`
+* :doc:`testing`
 
 .. toctree::
    :maxdepth: 1
@@ -45,6 +46,7 @@ Documentation index
    create_model
    inspect_model
    run_model
+   testing
 
 **Help & Reference**
 

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -1,0 +1,36 @@
+.. _testing:
+
+Testing
+=======
+
+Testing and/or debugging the logic implemented in process classes can
+be achieved easily just by instantiating them. The xarray-simlab
+framework is not invasive and process classes can be used like other,
+regular Python classes.
+
+.. ipython:: python
+   :suppress:
+
+    import sys
+    sys.path.append('scripts')
+    from advection_model import InitUGauss
+
+Here is an example with one of the process classes created in section
+:doc:`create_model`:
+
+.. ipython:: python
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    gauss = InitUGauss(loc=0.3, scale=0.1, x=np.arange(0, 1.5, 0.01))
+    gauss.initialize()
+    @savefig gauss.png width=50%
+    plt.plot(gauss.x, gauss.u);
+
+Like for any other process class, the parameters of
+``InitUGauss.__init__`` correspond to each of the variables declared
+in that class with either ``intent='in'`` or ``intent='inout'``. Those
+parameters are "keyword only" (see `PEP 3102`_), i.e., it is not
+possible to set these as positional arguments.
+
+.. _`PEP 3102`: https://www.python.org/dev/peps/pep-3102/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -37,6 +37,9 @@ Enhancements
   to the (runtime) methods defined in process classes (:issue:`59`).
 - Better documentation with a minimal, yet illustrative example based
   on Game of Life (:issue:`61`).
+- A class decorated with ``process`` can now be instantiated
+  independently of any Model object. This is very useful for testing
+  and debugging (:issue:`63`).
 
 Bug fixes
 ~~~~~~~~~

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -33,24 +33,11 @@ def _get_embedded_process_cls(cls):
                                         .format(cls=cls))
 
 
-def ensure_process_decorated(cls):
-    try:
-        cls = cls.__xsimlab_cls__
-    except AttributeError:
-        pass
-
-    if not getattr(cls, "__xsimlab_process__", False):
-        raise NotAProcessClassError("{cls!r} is not a "
-                                    "process-decorated class.".format(cls=cls))
-
-
 def get_process_cls(obj_or_cls):
     if not inspect.isclass(obj_or_cls):
         cls = type(obj_or_cls)
     else:
         cls = obj_or_cls
-
-    ensure_process_decorated(cls)
 
     return _get_embedded_process_cls(cls)
 

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -4,6 +4,7 @@ import attr
 import pytest
 
 import xsimlab as xs
+from xsimlab.process import get_process_obj
 
 
 @xs.process
@@ -49,7 +50,7 @@ class ExampleProcess:
 
 @pytest.fixture
 def example_process_obj():
-    return ExampleProcess()
+    return get_process_obj(ExampleProcess)
 
 
 @pytest.fixture(scope='session')
@@ -85,7 +86,7 @@ def in_var_details():
 
 
 def _init_process(p_cls, p_name, model, store, store_keys=None, od_keys=None):
-    p_obj = p_cls()
+    p_obj = get_process_obj(p_cls)
     p_obj.__xsimlab_name__ = p_name
     p_obj.__xsimlab_model__ = model
     p_obj.__xsimlab_store__ = store

--- a/xsimlab/tests/test_formatting.py
+++ b/xsimlab/tests/test_formatting.py
@@ -4,6 +4,7 @@ import xsimlab as xs
 from xsimlab.formatting import (maybe_truncate, pretty_print,
                                 repr_process, repr_model,
                                 var_details, wrap_indent)
+from xsimlab.process import get_process_obj
 
 
 def test_maybe_truncate():
@@ -60,7 +61,7 @@ def test_process_repr(example_process_obj, processes_with_store,
         run_step
     """)
 
-    assert repr_process(Dummy()) == expected
+    assert repr_process(get_process_obj(Dummy)) == expected
 
 
 def test_model_repr(simple_model, simple_model_repr):

--- a/xsimlab/tests/test_model.py
+++ b/xsimlab/tests/test_model.py
@@ -1,6 +1,7 @@
 import pytest
 
 import xsimlab as xs
+from xsimlab.process import get_process_cls
 from xsimlab.tests.fixture_model import AddOnDemand, InitProfile, Profile
 
 
@@ -113,7 +114,7 @@ class TestModelBuilder:
         new_model = model.update_processes(
             {'profile': InheritedProfile})
 
-        assert type(new_model['profile']) is InheritedProfile
+        assert type(new_model['profile']) is get_process_cls(InheritedProfile)
         assert isinstance(new_model['profile'], Profile)
 
         with pytest.raises(ValueError) as excinfo:
@@ -125,10 +126,6 @@ class TestModelBuilder:
 class TestModel:
 
     def test_constructor(self):
-        with pytest.raises(TypeError) as excinfo:
-            xs.Model({'init_profile': InitProfile()})
-        assert "values must be classes" in str(excinfo.value)
-
         with pytest.raises(KeyError) as excinfo:
             xs.Model({'init_profile': InitProfile})
         assert "Process class 'Profile' missing" in str(excinfo.value)

--- a/xsimlab/tests/test_process.py
+++ b/xsimlab/tests/test_process.py
@@ -4,7 +4,7 @@ import pytest
 
 import xsimlab as xs
 from xsimlab.variable import VarIntent, VarType
-from xsimlab.process import (ensure_process_decorated, filter_variables,
+from xsimlab.process import (filter_variables,
                              get_process_cls, get_process_obj,
                              get_target_variable, NotAProcessClassError,
                              process_info, variable_info)
@@ -12,23 +12,30 @@ from xsimlab.utils import variables_dict
 from xsimlab.tests.fixture_process import ExampleProcess, SomeProcess
 
 
-def test_ensure_process_decorated():
+def test_get_process_cls(example_process_obj):
+    p_cls = get_process_cls(ExampleProcess)
+    assert get_process_cls(example_process_obj) is p_cls
+
+
+def test_get_process_obj(example_process_obj):
+    p_cls = get_process_cls(ExampleProcess)
+    assert type(get_process_obj(ExampleProcess)) is p_cls
+
+    # get_process_obj returns a new instance
+    assert get_process_obj(example_process_obj) is not example_process_obj
+
+
+def test_get_process_raise():
     class NotAProcess:
         pass
 
     with pytest.raises(NotAProcessClassError) as excinfo:
-        ensure_process_decorated(NotAProcess)
+        get_process_cls(NotAProcess)
     assert "is not a process-decorated class" in str(excinfo.value)
 
-
-def test_get_process_cls(example_process_obj):
-    assert get_process_cls(ExampleProcess) is ExampleProcess
-    assert get_process_cls(example_process_obj) is ExampleProcess
-
-
-def test_get_process_obj(example_process_obj):
-    assert get_process_obj(example_process_obj) is example_process_obj
-    assert type(get_process_obj(ExampleProcess)) is ExampleProcess
+    with pytest.raises(NotAProcessClassError) as excinfo:
+        get_process_obj(NotAProcess)
+    assert "is not a process-decorated class" in str(excinfo.value)
 
 
 @pytest.mark.parametrize('kwargs,expected', [
@@ -50,26 +57,30 @@ def test_filter_variables(kwargs, expected):
     assert set(filter_variables(ExampleProcess, **kwargs)) == expected
 
 
-@pytest.mark.parametrize('var_name,expected_p_cls,expected_var_name', [
+@pytest.mark.parametrize('var_name,expected_cls,expected_var_name', [
     ('in_var', ExampleProcess, 'in_var'),
     ('in_foreign_var', SomeProcess, 'some_var'),
     ('in_foreign_var2', SomeProcess, 'some_var')  # test foreign of foreign
 ])
-def test_get_target_variable(var_name, expected_p_cls, expected_var_name):
-    var = variables_dict(ExampleProcess)[var_name]
+def test_get_target_variable(var_name, expected_cls, expected_var_name):
+    _ExampleProcess = get_process_cls(ExampleProcess)
+    expected_p_cls = get_process_cls(expected_cls)
+
+    var = variables_dict(_ExampleProcess)[var_name]
     expected_var = variables_dict(expected_p_cls)[expected_var_name]
 
-    actual_p_cls, actual_var = get_target_variable(var)
+    actual_cls, actual_var = get_target_variable(var)
 
-    if expected_p_cls is ExampleProcess:
-        assert actual_p_cls is None
+    if expected_p_cls is _ExampleProcess:
+        assert actual_cls is None
     else:
+        actual_p_cls = get_process_cls(actual_cls)
         assert actual_p_cls is expected_p_cls
 
     assert actual_var is expected_var
 
 
-@pytest.mark.parametrize('p_cls,var_name,prop_is_read_only', [
+@pytest.mark.parametrize('cls,var_name,prop_is_read_only', [
     (ExampleProcess, 'in_var', True),
     (ExampleProcess, 'in_foreign_var', True),
     (ExampleProcess, 'group_var', True),
@@ -78,7 +89,9 @@ def test_get_target_variable(var_name, expected_p_cls, expected_var_name):
     (ExampleProcess, 'out_var', False),
     (ExampleProcess, 'out_foreign_var', False)
 ])
-def test_process_properties_readonly(p_cls, var_name, prop_is_read_only):
+def test_process_properties_readonly(cls, var_name, prop_is_read_only):
+    p_cls = get_process_cls(cls)
+
     if prop_is_read_only:
         assert getattr(p_cls, var_name).fset is None
     else:
@@ -112,7 +125,9 @@ def test_process_properties_docstrings(in_var_details):
     # order of lines in string is not ensured (printed from a dictionary)
     to_lines = lambda details_str: sorted(details_str.split('\n'))
 
-    assert to_lines(ExampleProcess.in_var.__doc__) == to_lines(in_var_details)
+    _ExampleProcess = get_process_cls(ExampleProcess)
+
+    assert to_lines(_ExampleProcess.in_var.__doc__) == to_lines(in_var_details)
 
 
 def test_process_properties_values(processes_with_store):

--- a/xsimlab/tests/test_process.py
+++ b/xsimlab/tests/test_process.py
@@ -1,4 +1,5 @@
 from io import StringIO
+import inspect
 
 import pytest
 
@@ -209,6 +210,28 @@ def test_process_decorator():
         @xs.process(autodoc=True)
         class Dummy:
             pass
+
+
+def test_process_no_model():
+    params = inspect.signature(ExampleProcess.__init__).parameters
+
+    expected_params = ['self', 'in_var', 'inout_var', 'in_foreign_var',
+                       'in_foreign_var2', 'in_foreign_od_var', 'group_var']
+
+    assert list(params.keys()) == expected_params
+
+    @xs.process
+    class P:
+        invar = xs.variable()
+        outvar = xs.variable(intent='out')
+
+        def initialize(self):
+            self.outvar = self.invar + 2
+
+    p = P(invar=1)
+    p.initialize()
+
+    assert p.outvar == 3
 
 
 def test_process_info(example_process_obj, example_process_repr):

--- a/xsimlab/tests/test_utils.py
+++ b/xsimlab/tests/test_utils.py
@@ -2,6 +2,7 @@ import attr
 import pytest
 
 from xsimlab import utils
+from xsimlab.process import get_process_cls
 from xsimlab.tests.fixture_process import ExampleProcess
 
 
@@ -13,8 +14,10 @@ def test_variables_dict():
 
 
 def test_has_method():
-    assert utils.has_method(ExampleProcess(), 'compute_od_var')
-    assert not utils.has_method(ExampleProcess(), 'invalid_meth')
+    _ExampleProcess = get_process_cls(ExampleProcess)
+
+    assert utils.has_method(_ExampleProcess(), 'compute_od_var')
+    assert not utils.has_method(_ExampleProcess(), 'invalid_meth')
 
 
 def test_maybe_to_list():

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -132,8 +132,15 @@ def variable(dims=(), intent='in', group=None, default=attr.NOTHING,
                 'attrs': attrs or {},
                 'description': description}
 
+    if VarIntent(intent) == VarIntent.OUT:
+        _init = False
+        _repr = False
+    else:
+        _init = True
+        _repr = True
+
     return attr.attrib(metadata=metadata, default=default, validator=validator,
-                       init=False, cmp=False, repr=False)
+                       init=_init, cmp=False, repr=_repr)
 
 
 def on_demand(dims=(), group=None, description='', attrs=None):
@@ -229,7 +236,14 @@ def foreign(other_process_cls, var_name, intent='in'):
                 'intent': VarIntent(intent),
                 'description': description}
 
-    return attr.attrib(metadata=metadata, init=False, cmp=False, repr=False)
+    if VarIntent(intent) == VarIntent.OUT:
+        _init = False
+        _repr = False
+    else:
+        _init = True
+        _repr = True
+
+    return attr.attrib(metadata=metadata, init=_init, cmp=False, repr=_repr)
 
 
 def group(name):
@@ -260,4 +274,5 @@ def group(name):
                 'intent': VarIntent.IN,
                 'description': description}
 
-    return attr.attrib(metadata=metadata, init=False, cmp=False, repr=False)
+    return attr.attrib(metadata=metadata, init=True, cmp=False, repr=True,
+                       default=tuple())

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -140,7 +140,7 @@ def variable(dims=(), intent='in', group=None, default=attr.NOTHING,
         _repr = True
 
     return attr.attrib(metadata=metadata, default=default, validator=validator,
-                       init=_init, cmp=False, repr=_repr)
+                       init=_init, cmp=False, repr=_repr, kw_only=True)
 
 
 def on_demand(dims=(), group=None, description='', attrs=None):
@@ -243,7 +243,8 @@ def foreign(other_process_cls, var_name, intent='in'):
         _init = True
         _repr = True
 
-    return attr.attrib(metadata=metadata, init=_init, cmp=False, repr=_repr)
+    return attr.attrib(metadata=metadata, init=_init, cmp=False, repr=_repr,
+                       kw_only=True)
 
 
 def group(name):
@@ -275,4 +276,4 @@ def group(name):
                 'description': description}
 
     return attr.attrib(metadata=metadata, init=True, cmp=False, repr=True,
-                       default=tuple())
+                       default=tuple(), kw_only=True)


### PR DESCRIPTION
This is a follow-up on #59 towards a less invasive framework.

``@process`` is now a thin wrapper around ``attr.s``. Applied on a class ``A``, it returns the class (almost) just as it was decorated with ``attr.s``. The more invasive modifications (custom properties, etc.) are now in a subclass of ``A`` that is created programmatically and accessible from ``A.__xsimlab_cls__`` (Model objects use the latter subclass instead of ``A`` directly).

The great advantage is that it is now possible to use instances of process-decorated classes independently of any Model, which is IMO a better solution than the approach proposed in #50 for testing the logic implemented in those classes.

Variables declared with ``intent='in'`` or ``intent='inout'`` are now included in``__init__`` generated by attr.

An alternative approach would be to stick with one single class and customize its ``__init__`` to circumvent the limitation of read-only properties created for input variables (see, e.g., https://github.com/python-attrs/attrs/issues/393#issuecomment-510148031). This is maybe less complicated than the approach used here, but it still alters the class significantly.

TODO:

- [x] check if this approach works with #45 (subclass).
- [x] set ``init=True`` and ``repr=True`` for all input variables
- [x] add tests
- [x] update docs (new "testing" section)
- [x] update release notes