### PR TITLE
Allows setting multiple groups for a variable

### DIFF
--- a/doc/framework.rst
+++ b/doc/framework.rst
@@ -132,12 +132,12 @@ Group variables
 In some cases, using group variables may provide an elegant
 alternative to hard-coded links between processes.
 
-The membership of variables to a group is defined via their ``group``
-attribute. If you want to use in a separate process all the variables
-of a group, instead of explicitly declaring foreign variables you can
-declare a :func:`~xsimlab.group` variable. The latter behaves like an
-iterable of foreign variables pointing to each of the variables that
-are members of the group, across the model.
+The membership of variables to one or several groups is defined via their
+``groups`` attribute. If you want to use in a separate process all the variables
+of a group, instead of explicitly declaring foreign variables you can declare a
+:func:`~xsimlab.group` variable. The latter behaves like an iterable of foreign
+variables pointing to each of the variables that are members of the group,
+across the model.
 
 Note that group variables only support ``intent='in'``, i.e, group
 variables should only be used to get the values of multiple foreign

--- a/doc/scripts/advection_model.py
+++ b/doc/scripts/advection_model.py
@@ -72,7 +72,7 @@ class AdvectionLax:
     v = xs.variable(dims=[(), 'x'], description='velocity')
     grid_spacing = xs.foreign(UniformGrid1D, 'spacing')
     u = xs.foreign(ProfileU, 'u')
-    u_advected = xs.variable(dims='x', intent='out', group='u_vars')
+    u_advected = xs.variable(dims='x', intent='out', groups='u_vars')
 
     @xs.runtime(args='step_delta')
     def run_step(self, dt):
@@ -115,7 +115,7 @@ class SourcePoint:
     loc = xs.variable(description='source location')
     flux = xs.variable(description='source flux')
     x = xs.foreign(UniformGrid1D, 'x')
-    u_source = xs.variable(dims='x', intent='out', group='u_vars')
+    u_source = xs.variable(dims='x', intent='out', groups='u_vars')
 
     @property
     def nearest_node(self):

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,6 +11,18 @@ Breaking changes
 
 - Python 3.6 is now the oldest supported version (:issue:`70`).
 
+Depreciations
+~~~~~~~~~~~~~
+
+- Using the ``group`` parameter in ``xsimlab.variable`` and
+  ``xsimlab.on_demand`` is depreciated; use ``groups`` instead.
+
+Enhancements
+~~~~~~~~~~~~
+
+- It is now possible to assign multiple groups to a single variable
+  (:issue:`71`).
+
 Bug fixes
 ~~~~~~~~~
 
@@ -33,8 +45,8 @@ Breaking changes
   and ``Model.finalize`` have been removed in favor of
   ``Model.execute`` (:issue:`59`).
 
-Deprecations
-~~~~~~~~~~~~
+Depreciations
+~~~~~~~~~~~~~
 
 - ``run_step`` methods defined in process classes won't accept anymore
   current step duration as a positional argument by default. Use the

--- a/xsimlab/formatting.py
+++ b/xsimlab/formatting.py
@@ -51,7 +51,7 @@ def _summarize_var(var, process, col_width):
         var_intent_str = '[inout]'
 
     if var_type == VarType.GROUP:
-        var_info = '{} group {!r}'.format(link_symbol, var.metadata['groups'])
+        var_info = '{} group {!r}'.format(link_symbol, var.metadata['group'])
 
     elif var_type == VarType.FOREIGN:
         key = process.__xsimlab_store_keys__.get(var_name)

--- a/xsimlab/formatting.py
+++ b/xsimlab/formatting.py
@@ -51,7 +51,7 @@ def _summarize_var(var, process, col_width):
         var_intent_str = '[inout]'
 
     if var_type == VarType.GROUP:
-        var_info = '{} group {!r}'.format(link_symbol, var.metadata['group'])
+        var_info = '{} group {!r}'.format(link_symbol, var.metadata['groups'])
 
     elif var_type == VarType.FOREIGN:
         key = process.__xsimlab_store_keys__.get(var_name)

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -1,10 +1,9 @@
 from collections import OrderedDict, defaultdict
-from inspect import isclass
 
 from .variable import VarIntent, VarType
 from .process import (filter_variables, get_process_cls,
                       get_target_variable, SimulationStage)
-from .utils import AttrMapping, ContextMixin, has_method, variables_dict
+from .utils import AttrMapping, ContextMixin, variables_dict
 from .formatting import repr_model
 
 
@@ -39,6 +38,7 @@ class _ModelBuilder:
       step of a simulation
 
     """
+   
     def __init__(self, processes_cls):
         self._processes_cls = processes_cls
         self._processes_obj = {k: cls() for k, cls in processes_cls.items()}
@@ -124,7 +124,7 @@ class _ModelBuilder:
             store_key, od_key = self._get_var_key(target_p_name, target_var)
 
         elif var_type == VarType.GROUP:
-            var_group = var.metadata['group']
+            var_group = var.metadata['groups']
             store_key, od_key = self._get_group_var_keys(var_group)
 
         return store_key, od_key
@@ -140,8 +140,9 @@ class _ModelBuilder:
         store_keys = []
         od_keys = []
 
-        filter_group = lambda var: (var.metadata.get('group') == group and
-                                    var.metadata['var_type'] != VarType.GROUP)
+        def filter_group(var):
+            return (var.metadata.get('groups') == group and
+                    var.metadata['var_type'] != VarType.GROUP)
 
         for p_name, p_obj in self._processes_obj.items():
             for var in filter_variables(p_obj, func=filter_group).values():
@@ -179,10 +180,9 @@ class _ModelBuilder:
         intent='out' targets the same variable.
 
         """
-        filter_out = lambda var: (
-            var.metadata['intent'] == VarIntent.OUT and
-            var.metadata['var_type'] != VarType.ON_DEMAND
-        )
+        def filter_out(var):
+            return (var.metadata['intent'] == VarIntent.OUT and
+                    var.metadata['var_type'] != VarType.ON_DEMAND)
 
         targets = defaultdict(list)
 
@@ -227,11 +227,12 @@ class _ModelBuilder:
           model inputs.
 
         """
-        filter_in = lambda var: (
-            var.metadata['var_type'] != VarType.GROUP and
-            var.metadata['intent'] != VarIntent.OUT
-        )
-        filter_out = lambda var: var.metadata['intent'] == VarIntent.OUT
+        def filter_in(var):
+            return (var.metadata['var_type'] != VarType.GROUP and
+                    var.metadata['intent'] != VarIntent.OUT)
+
+        def filter_out(var):
+            return var.metadata['intent'] == VarIntent.OUT
 
         in_keys = []
         out_keys = []
@@ -381,6 +382,7 @@ class Model(AttrMapping, ContextMixin):
     value before running the model.
 
     """
+
     def __init__(self, processes):
         """
         Parameters

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -124,7 +124,7 @@ class _ModelBuilder:
             store_key, od_key = self._get_var_key(target_p_name, target_var)
 
         elif var_type == VarType.GROUP:
-            var_group = var.metadata['groups']
+            var_group = var.metadata['group']
             store_key, od_key = self._get_group_var_keys(var_group)
 
         return store_key, od_key
@@ -140,12 +140,8 @@ class _ModelBuilder:
         store_keys = []
         od_keys = []
 
-        def filter_group(var):
-            return (var.metadata.get('groups') == group and
-                    var.metadata['var_type'] != VarType.GROUP)
-
         for p_name, p_obj in self._processes_obj.items():
-            for var in filter_variables(p_obj, func=filter_group).values():
+            for var in filter_variables(p_obj, group=group).values():
                 store_key, od_key = self._get_var_key(p_name, var)
 
                 if store_key is not None:

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -92,7 +92,7 @@ def filter_variables(process, var_type=None, intent=None, group=None,
 
     if group is not None:
         vars = {k: v for k, v in vars.items()
-                if v.metadata.get('groups') == group}
+                if group in v.metadata.get('groups', [])}
 
     if func is not None:
         vars = {k: v for k, v in vars.items() if func(v)}

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -92,7 +92,7 @@ def filter_variables(process, var_type=None, intent=None, group=None,
 
     if group is not None:
         vars = {k: v for k, v in vars.items()
-                if v.metadata.get('group') == group}
+                if v.metadata.get('groups') == group}
 
     if func is not None:
         vars = {k: v for k, v in vars.items() if func(v)}

--- a/xsimlab/tests/fixture_model.py
+++ b/xsimlab/tests/fixture_model.py
@@ -47,7 +47,7 @@ class Roll:
     shift = xs.variable(description=('shift profile by a nb. of points'),
                         attrs={'units': 'unitless'})
     u = xs.foreign(Profile, 'u')
-    u_diff = xs.variable(dims='x', group='diff', intent='out')
+    u_diff = xs.variable(dims='x', groups='diff', intent='out')
 
     def run_step(self):
         self.u_diff = np.roll(self.u, self.shift) - self.u
@@ -57,7 +57,7 @@ class Roll:
 class Add:
     offset = xs.variable(description=('offset * dt added every time step '
                                       'to profile u'))
-    u_diff = xs.variable(group='diff', intent='out')
+    u_diff = xs.variable(groups='diff', intent='out')
 
     @xs.runtime(args='step_delta')
     def run_step(self, dt):
@@ -67,7 +67,7 @@ class Add:
 @xs.process
 class AddOnDemand:
     offset = xs.variable(description='offset added to profile u')
-    u_diff = xs.on_demand(group='diff')
+    u_diff = xs.on_demand(groups='diff')
 
     @u_diff.compute
     def _compute_u_diff(self):

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -80,7 +80,7 @@ def in_var_details():
     - type : variable
     - intent : in
     - dims : (('x',), ('x', 'y'))
-    - groups : None
+    - groups : ()
     - attrs : {}
     """)
 

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -10,8 +10,8 @@ from xsimlab.process import get_process_obj
 @xs.process
 class SomeProcess:
     """Just used for foreign variables in ExampleProcess."""
-    some_var = xs.variable(group='some_group', intent='out')
-    some_od_var = xs.on_demand(group='some_group')
+    some_var = xs.variable(groups='some_group', intent='out')
+    some_od_var = xs.on_demand(groups='some_group')
 
     @some_od_var.compute
     def compute_some_od_var(self):
@@ -29,7 +29,7 @@ class AnotherProcess:
 class ExampleProcess:
     """A process with complete interface for testing."""
     in_var = xs.variable(dims=['x', ('x', 'y')], description='input variable')
-    out_var = xs.variable(group='example_group', intent='out')
+    out_var = xs.variable(groups='example_group', intent='out')
     inout_var = xs.variable(intent='inout')
     od_var = xs.on_demand()
 

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -80,7 +80,7 @@ def in_var_details():
     - type : variable
     - intent : in
     - dims : (('x',), ('x', 'y'))
-    - group : None
+    - groups : None
     - attrs : {}
     """)
 

--- a/xsimlab/tests/test_model.py
+++ b/xsimlab/tests/test_model.py
@@ -48,6 +48,21 @@ class TestModelBuilder:
         assert actual_store_keys == expected_store_keys
         assert actual_od_keys == expected_od_keys
 
+    def test_multiple_groups(self):
+        @xs.process
+        class A:
+            v = xs.variable(groups=['g1', 'g2'])
+
+        @xs.process
+        class B:
+            g1 = xs.group('g1')
+            g2 = xs.group('g2')
+
+        m = xs.Model({'a': A, 'b': B})
+
+        assert m.b.__xsimlab_store_keys__['g1'] == [('a', 'v')]
+        assert m.b.__xsimlab_store_keys__['g2'] == [('a', 'v')]
+
     def test_get_all_variables(self, model):
         assert all([len(t) == 2 for t in model.all_vars])
         assert all([p_name in model for p_name, _ in model.all_vars])

--- a/xsimlab/tests/test_variable.py
+++ b/xsimlab/tests/test_variable.py
@@ -1,7 +1,7 @@
 import pytest
 
 from xsimlab.tests.fixture_process import ExampleProcess
-from xsimlab.variable import _as_dim_tuple, foreign
+from xsimlab.variable import _as_dim_tuple, _as_group_tuple, foreign
 
 
 @pytest.mark.parametrize("dims,expected", [
@@ -25,6 +25,24 @@ def test_as_dim_tuple_invalid():
         _as_dim_tuple(invalid_dims)
     assert "following combinations" in str(excinfo.value)
     assert "('x',), ('y',) and ('x', 'y'), ('y', 'x')" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("groups,group,expected", [
+    (None, None, ()),
+    ('group1', None, ('group1',)),
+    (['group1', 'group2'], None, ('group1', 'group2')),
+    ('group1', 'group2', ('group1', 'group2')),
+    ('group1', 'group1', ('group1',))
+])
+def test_as_group_tuple(groups, group, expected):
+    if group is not None:
+        with pytest.warns(FutureWarning):
+            actual = _as_group_tuple(groups, group)
+
+    else:
+        actual = _as_group_tuple(groups, group)
+
+    assert actual == expected
 
 
 def test_foreign():

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -128,7 +128,7 @@ def variable(dims=(), intent='in', group=None, default=attr.NOTHING,
     metadata = {'var_type': VarType.VARIABLE,
                 'dims': _as_dim_tuple(dims),
                 'intent': VarIntent(intent),
-                'group': group,
+                'groups': group,
                 'attrs': attrs or {},
                 'description': description}
 
@@ -187,7 +187,7 @@ def on_demand(dims=(), group=None, description='', attrs=None):
     metadata = {'var_type': VarType.ON_DEMAND,
                 'dims': _as_dim_tuple(dims),
                 'intent': VarIntent.OUT,
-                'group': group,
+                'groups': group,
                 'attrs': attrs or {},
                 'description': description}
 
@@ -270,7 +270,7 @@ def group(name):
                    "belong to group {!r}".format(name))
 
     metadata = {'var_type': VarType.GROUP,
-                'group': name,
+                'groups': name,
                 'intent': VarIntent.IN,
                 'description': description}
 


### PR DESCRIPTION
Closes #64 

The ``group`` parameter of ``xsimlab.variable()`` and ``xsimlab.on_demand()`` is depreciated in favor of the newly introduced ``groups`` parameter. 