### PR TITLE
Update doc examples and citation sections

### DIFF
--- a/doc/citation.rst
+++ b/doc/citation.rst
@@ -1,7 +1,7 @@
 .. _citation:
 
-Citation
-========
+Citation & References
+=====================
 
 If you want to use and cite xarray-simlab in a scientific publication,
 we provide citations and DOIs for specific versions via Zenodo. Click
@@ -10,3 +10,11 @@ of xarray-simlab.
 
 .. image:: https://zenodo.org/badge/93938479.svg
    :target: https://zenodo.org/badge/latestdoi/93938479
+
+xarray-simlab has been used in the following publications (please reach us if
+you'd like to add a publication to the list below):
+
+- Kaandorp, V.P., Doornenbal, P.J., Kooi, H., Peter Broers, H., de Louw,
+  P.G.B., 2019. Temperature buffering by groundwater in ecologically valuable
+  lowland streams under current and future climate conditions. Journal of
+  Hydrology X 3, 100031. https://doi.org/10.1016/j.hydroa.2019.100031

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,7 +60,6 @@ extensions = [
     'sphinx.ext.todo',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
-    'nbsphinx',
 ]
 
 extlinks = {

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -14,5 +14,4 @@ dependencies:
   - python-graphviz
   - nbconvert=5.6.0
   - sphinx=1.8.5
-  - nbsphinx=0.4.2
   - pandoc=2.7.3

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -1,13 +1,22 @@
 .. _examples:
 
-Examples
-========
+Examples & Related Projects
+===========================
 
-An example of simple advection is given in the user guide
-sections. Here below are more advanced examples of using
-xarray-simlab.
+Basic examples
+--------------
 
-.. toctree::
-    :maxdepth: 2
+Some basic examples can be found in this documentation, e.g.,
 
-    examples/landscape-evolution-model
+- A minimal example, based on the Game of Life, shown in :doc:`about`.
+- An example of simple advection shown in the user guide (see
+  :doc:`create_model` and :doc:`run_model`).
+
+Related projects
+----------------
+
+More detailled examples can be found in 3rd-party projects built on top of
+xarray-simlab (please tell us if you want to add your project to the list
+below):
+
+- `fastscape <https://fastscape.readthedocs.io>`_: landscape evolution modeling.


### PR DESCRIPTION
Removed notebook example, and instead added a link to `fastscape`.

It's better to have self-contained examples in the docs, and just add links for examples that depend on 3rd-party tools.

