### PR TITLE
Refactor ``output_vars`` in the xarray extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ by Jake VanderPlas.
         model=model,
         clocks={'step': np.arange(9)},
         input_vars={'init__pos': ('point_xy', [4, 5])},
-        output_vars={'step': 'gol__world'}
+        output_vars={'gol__world': 'step'}
     )
 
     output_dataset = input_dataset.xsimlab.run(model=model)

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -77,7 +77,7 @@ by Jake VanderPlas.
        ...:     model=model,
        ...:     clocks={'step': np.arange(9)},
        ...:     input_vars={'init__pos': ('point_xy', [4, 5])},
-       ...:     output_vars={'step': 'gol__world'}
+       ...:     output_vars={'gol__world': 'step'}
        ...: )
        ...:
        ...: output_dataset = input_dataset.xsimlab.run(model=model)

--- a/doc/run_model.rst
+++ b/doc/run_model.rst
@@ -48,14 +48,20 @@ create a new setup in a very declarative way:
 
     in_ds = xs.create_setup(
         model=model2,
-        clocks={'time': np.linspace(0., 1., 101),
-                'otime': [0, 0.5, 1]},
+        clocks={
+            'time': np.linspace(0., 1., 101),
+            'otime': [0, 0.5, 1]
+        },
         master_clock='time',
-        input_vars={'grid': {'length': 1.5, 'spacing': 0.01},
-                    'init': {'loc': 0.3, 'scale': 0.1},
-                    'advect': {'v': 1.}},
-        output_vars={None: {'grid': 'x'},
-                     'otime': {'profile': 'u'}}
+        input_vars={
+            'grid': {'length': 1.5, 'spacing': 0.01},
+            'init': {'loc': 0.3, 'scale': 0.1},
+            'advect__v': 1.
+        },
+        output_vars={
+            'grid__x': None,
+            'profile__u': 'otime'
+        }
     )
 
 A setup consists in:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,19 +10,19 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 - Python 3.6 is now the oldest supported version (:issue:`70`).
-- The keys of the dictionary returned by ``xarray.Dataset.xsimlab.output_vars``
-  now correspond to variable names, and the values are clock dimension labels or
-  ``None`` (previously the dictionary was formatted the other way around)
-  (:issue:`85`).
+- The keys of the dictionary returned by
+  :attr:`xarray.Dataset.xsimlab.output_vars` now correspond to variable names,
+  and the values are clock dimension labels or ``None`` (previously the
+  dictionary was formatted the other way around) (:issue:`85`).
 
 Depreciations
 ~~~~~~~~~~~~~
 
-- Using the ``group`` parameter in ``xsimlab.variable`` and
-  ``xsimlab.on_demand`` is depreciated; use ``groups`` instead.
+- Using the ``group`` parameter in :func:`xsimlab.variable` and
+  :func:`xsimlab.on_demand` is depreciated; use ``groups`` instead.
 - Providing a dictionary with clock dimensions or ``None`` as keys to
-  ``output_vars`` in ``xarray.Dataset.xsimlab.update_vars()`` and
-  ``xsimlab.create_setup()`` is depreciated. Variable names should be used
+  ``output_vars`` in :func:`xarray.Dataset.xsimlab.update_vars()` and
+  :func:`xsimlab.create_setup()` is depreciated. Variable names should be used
   instead (:issue:`85`).
 
 Enhancements

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,12 +10,20 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 - Python 3.6 is now the oldest supported version (:issue:`70`).
+- The keys of the dictionary returned by ``xarray.Dataset.xsimlab.output_vars``
+  now correspond to variable names, and the values are clock dimension labels or
+  ``None`` (previously the dictionary was formatted the other way around)
+  (:issue:`85`).
 
 Depreciations
 ~~~~~~~~~~~~~
 
 - Using the ``group`` parameter in ``xsimlab.variable`` and
   ``xsimlab.on_demand`` is depreciated; use ``groups`` instead.
+- Providing a dictionary with clock dimensions or ``None`` as keys to
+  ``output_vars`` in ``xarray.Dataset.xsimlab.update_vars()`` and
+  ``xsimlab.create_setup()`` is depreciated. Variable names should be used
+  instead (:issue:`85`).
 
 Enhancements
 ~~~~~~~~~~~~
@@ -37,6 +45,8 @@ Enhancements
   input xarray Datasets to match those defined in model variables (:issue:`76`).
   This is optional and controlled by the parameter ``check_dims`` added
   to :func:`xarray.Dataset.xsimlab.run`.
+- More consistent dictionary format for output variables in the xarray
+  extension (:issue:`85`).
 
 Bug fixes
 ~~~~~~~~~

--- a/xsimlab/tests/test_drivers.py
+++ b/xsimlab/tests/test_drivers.py
@@ -109,6 +109,7 @@ class TestXarraySimulationDriver:
         expected = {
             "clock": np.array([True, True, True, True, True]),
             "out": np.array([True, False, True, False, True]),
+            None: np.array([False, False, False, False, True]),
         }
 
         assert xarray_driver.output_save_steps.keys() == expected.keys()

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -284,7 +284,7 @@ class TestSimlabAccessor:
             ("profile", "u_opp"): None,
             ("profile", "u"): "clock",
             ("roll", "u_diff"): "out",
-            ("add", "u_diff"): "out"
+            ("add", "u_diff"): "out",
         }
 
         ds = xs.create_setup(
@@ -293,10 +293,10 @@ class TestSimlabAccessor:
                 "clock": [0, 2, 4, 6, 8],
                 "out": [0, 4, 8],
                 # snapshot clock with no output variable
-                "out2": [0, 8]
+                "out2": [0, 8],
             },
             master_clock="clock",
-            output_vars=o_vars
+            output_vars=o_vars,
         )
 
         assert ds.xsimlab.output_vars == o_vars

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -258,46 +258,42 @@ class TestSimlabAccessor:
         ds["out"] = ("out", [0, 4, 8], {self._clock_key: 1})
         ds["not_a_clock"] = ("not_a_clock", [0, 1])
 
-        with pytest.raises(KeyError) as excinfo:
-            ds.xsimlab._set_output_vars(model, None, [("invalid", "var")])
-        assert "not valid key(s)" in str(excinfo.value)
+        with pytest.raises(KeyError, match=r".*not valid key.*"):
+            ds.xsimlab._set_output_vars(model, {("invalid", "var"): None})
 
-        ds.xsimlab._set_output_vars(model, None, [("profile", "u_opp")])
+        ds.xsimlab._set_output_vars(model, {("profile", "u_opp"): None})
         assert ds.attrs[self._output_vars_key] == "profile__u_opp"
 
         ds.xsimlab._set_output_vars(
-            model, "out", [("roll", "u_diff"), ("add", "u_diff")]
+            model, {("roll", "u_diff"): "out", ("add", "u_diff"): "out"}
         )
         expected = "roll__u_diff,add__u_diff"
         assert ds["out"].attrs[self._output_vars_key] == expected
 
-        with pytest.raises(ValueError) as excinfo:
-            ds.xsimlab._set_output_vars(model, "not_a_clock", [("profile", "u")])
-        assert "not a valid clock" in str(excinfo.value)
+        with pytest.raises(ValueError, match=r".not a valid clock.*"):
+            ds.xsimlab._set_output_vars(model, {("profile", "u"): "not_a_clock"})
 
     def test_output_vars(self, model):
-        ds = xr.Dataset()
-        ds["clock"] = (
-            "clock",
-            [0, 2, 4, 6, 8],
-            {self._clock_key: 1, self._master_clock_key: 1},
-        )
-        ds["out"] = ("out", [0, 4, 8], {self._clock_key: 1})
-        # snapshot clock with no output variable (attribute) set
-        ds["out2"] = ("out2", [0, 8], {self._clock_key: 1})
-
-        ds.xsimlab._set_output_vars(model, None, [("profile", "u_opp")])
-        ds.xsimlab._set_output_vars(model, "clock", [("profile", "u")])
-        ds.xsimlab._set_output_vars(
-            model, "out", [("roll", "u_diff"), ("add", "u_diff")]
-        )
-
-        expected = {
-            None: [("profile", "u_opp")],
-            "clock": [("profile", "u")],
-            "out": [("roll", "u_diff"), ("add", "u_diff")],
+        o_vars = {
+            ("profile", "u_opp"): None,
+            ("profile", "u"): "clock",
+            ("roll", "u_diff"): "out",
+            ("add", "u_diff"): "out"
         }
-        assert ds.xsimlab.output_vars == expected
+
+        ds = xs.create_setup(
+            model=model,
+            clocks={
+                "clock": [0, 2, 4, 6, 8],
+                "out": [0, 4, 8],
+                # snapshot clock with no output variable
+                "out2": [0, 8]
+            },
+            master_clock="clock",
+            output_vars=o_vars
+        )
+
+        assert ds.xsimlab.output_vars == o_vars
 
     def test_run_safe_mode(self, model, in_dataset):
         # safe mode True: ensure model is cloned

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -82,7 +82,7 @@ def _as_group_tuple(groups, group):
 
     if group is not None:
         warnings.warn(
-            "Setting variable group using `group` is depreciated; " "use `groups`.",
+            "Setting variable group using `group` is depreciated; use `groups`.",
             FutureWarning,
             stacklevel=2,
         )

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -324,6 +324,7 @@ class SimlabAccessor:
         name (or None) on which to save snapshots as values.
 
         """
+
         def xr_attr_to_dict(attrs, clock):
             var_str = attrs.get(self._output_vars_key)
 

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -439,8 +439,8 @@ class SimlabAccessor:
             Model input values (may be grouped per process name, as dict of
             dicts).
         output_vars : dict, optional
-            Model variables to save as simulation output, given per
-            clock coordinate.
+            Model variables to save as simulation output (time-dependent or
+            time-independent).
 
         Returns
         -------
@@ -678,24 +678,13 @@ def create_setup(
         :class:`xarray.Variable` objects, e.g., single values, array-like,
         ``(dims, data, attrs)`` tuples or xarray objects.
     output_vars : dict, optional
-        Dictionary with model variable names to save as simulation output,
-        given per clock coordinate. Entries of the given dictionary may
-        look like:
-
-        - ``'dim': {'foo': 'bar'}`` or
-        - ``'dim': {'foo': ('bar', 'baz')}`` or
-        - ``'dim': ('foo', 'bar')`` or
-        - ``'dim': [('foo', 'bar'), ('foo', 'baz')]`` or
-        - ``'dim': 'foo__bar'`` or
-        - ``'dim': ['foo__bar', 'foo__baz']``
-
-        where ``foo`` is the name of a existing process in the model and
-        ``bar``, ``baz`` are the names of variables declared in that process.
-
-        If ``'dim'`` corresponds to the dimension of a clock coordinate,
-        new output values will be saved at each time given by the coordinate
-        labels. if None is given instead, only one value will be saved at the
-        end of the simulation.
+        Dictionary with model variable names to save as simulation output
+        (time-dependent or time-independent). Entries of the dictionary look
+        similar than for ``input_vars`` (see here above), except that here
+        ``value`` must correspond to the dimension of a clock coordinate
+        (i.e., new output values will be saved at each time given by the
+        coordinate labels) or ``None`` (i.e., only one value will be saved
+        at the end of the simulation).
     fill_default : bool, optional
         If True (default), automatically fill the dataset with all model
         inputs missing in ``input_vars`` and their default value (if any).

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -2,6 +2,8 @@
 xarray extensions (accessors).
 
 """
+from collections import defaultdict
+
 import attr
 import numpy as np
 from xarray import as_variable, Dataset, register_dataset_accessor
@@ -251,7 +253,26 @@ class SimlabAccessor:
 
             self._ds[xr_var_name] = xr_var
 
-    def _set_output_vars(self, model, clock, output_vars):
+    def _set_output_vars(self, model, output_vars, clear=False):
+        # TODO: remove this ugly code (depreciated output_vars format)
+        o_vars = {}
+
+        for k, v in output_vars.items():
+            if k is None or k in self.clock_coords:
+                o_vars.update({vn: k for vn in _flatten_outputs({k: v})[k]})
+
+            else:
+                o_vars[k] = v
+
+        output_vars = _flatten_inputs(o_vars)
+
+        # end of depreciated code block
+
+        if not clear:
+            _output_vars = self.output_vars
+            _output_vars.update(output_vars)
+            output_vars = _output_vars
+
         invalid_outputs = set(output_vars) - set(model.all_vars)
         if invalid_outputs:
             raise KeyError(
@@ -260,42 +281,57 @@ class SimlabAccessor:
                 )
             )
 
-        output_vars_str = ",".join(
-            [p_name + "__" + var_name for (p_name, var_name) in output_vars]
-        )
+        clock_vars = defaultdict(list)
 
-        if clock is None:
-            self._ds.attrs[self._output_vars_key] = output_vars_str
-
-        else:
-            if clock not in self.clock_coords:
+        for (p_name, var_name), clock in output_vars.items():
+            if clock is not None and clock not in self.clock_coords:
                 raise ValueError(
-                    "{!r} coordinate is not a valid clock " "coordinate.".format(clock)
+                    "{!r} coordinate is not a valid clock coordinate.".format(clock)
                 )
-            coord = self.clock_coords[clock]
-            coord.attrs[self._output_vars_key] = output_vars_str
 
-    def _maybe_update_output_vars(self, clock, ds_or_coord, output_vars):
-        out_attr = ds_or_coord.attrs.get(self._output_vars_key)
+            xr_var_name = p_name + "__" + var_name
+            clock_vars[clock].append(xr_var_name)
 
-        if out_attr is not None:
-            output_vars[clock] = [as_variable_key(k) for k in out_attr.split(",")]
+        for clock, var_list in clock_vars.items():
+            var_str = ",".join(var_list)
+
+            if clock is None:
+                self._ds.attrs[self._output_vars_key] = var_str
+            else:
+                coord = self.clock_coords[clock]
+                coord.attrs[self._output_vars_key] = var_str
+
+    def _reset_output_vars(self, model, output_vars):
+        self._ds.attrs.pop(self._output_vars_key, None)
+
+        for coord in self.clock_coords.values():
+            coord.attrs.pop(self._output_vars_key, None)
+
+        self._set_output_vars(model, output_vars, clear=True)
 
     @property
     def output_vars(self):
-        """Returns a dictionary of clock dimension names (or None) as keys and
-        output variable names - i.e. lists of ``('p_name', 'var_name')``
-        tuples - as values.
+        """Returns a dictionary of output variable names - in the form of
+        ``('p_name', 'var_name')`` tuples - as keys and the clock dimension
+        name (or None) on which to save snapshots as values.
 
         """
-        output_vars = {}
+        def xr_attr_to_dict(attrs, clock):
+            var_str = attrs.get(self._output_vars_key)
 
-        for clock, clock_coord in self.clock_coords.items():
-            self._maybe_update_output_vars(clock, clock_coord, output_vars)
+            if var_str is None:
+                return {}
+            else:
+                return {as_variable_key(k): clock for k in var_str.split(",")}
 
-        self._maybe_update_output_vars(None, self._ds, output_vars)
+        o_vars = {}
 
-        return output_vars
+        for clock, coord in self.clock_coords.items():
+            o_vars.update(xr_attr_to_dict(coord.attrs, clock))
+
+        o_vars.update(xr_attr_to_dict(self._ds.attrs, None))
+
+        return o_vars
 
     def update_clocks(self, model=None, clocks=None, master_clock=None):
         """Set or update clock coordinates.
@@ -374,9 +410,9 @@ class SimlabAccessor:
 
         ds.xsimlab._uniformize_clock_coords(**master_clock_dict)
 
-        for clock, var_keys in self.output_vars.items():
-            if clock is None or clock in ds:
-                ds.xsimlab._set_output_vars(model, clock, var_keys)
+        # operations on clock coords may have discarded coord attributes
+        o_vars = {k: v for k, v in self.output_vars.items() if v is None or v in ds}
+        ds.xsimlab._set_output_vars(model, o_vars)
 
         return ds
 
@@ -416,8 +452,7 @@ class SimlabAccessor:
             ds.xsimlab._set_input_vars(model, _flatten_inputs(input_vars))
 
         if output_vars is not None:
-            for clock, out_vars in _flatten_outputs(output_vars).items():
-                ds.xsimlab._set_output_vars(model, clock, out_vars)
+            ds.xsimlab._set_output_vars(model, output_vars)
 
         return ds
 
@@ -504,9 +539,8 @@ class SimlabAccessor:
         ds = self._ds.drop(drop_variables)
 
         # update output variable attributes
-        for clock, out_vars in self.output_vars.items():
-            new_out_vars = [key for key in out_vars if key in model.all_vars]
-            ds.xsimlab._set_output_vars(model, clock, new_out_vars)
+        o_vars = {k: v for k, v in self.output_vars.items() if k in model.all_vars}
+        ds.xsimlab._reset_output_vars(model, o_vars)
 
         return ds
 

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -321,7 +321,7 @@ class SimlabAccessor:
     def output_vars(self):
         """Returns a dictionary of output variable names - in the form of
         ``('p_name', 'var_name')`` tuples - as keys and the clock dimension
-        name (or None) on which to save snapshots as values.
+        names (or None) on which to save snapshots as values.
 
         """
 

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -3,6 +3,7 @@ xarray extensions (accessors).
 
 """
 from collections import defaultdict
+import warnings
 
 import attr
 import numpy as np
@@ -259,6 +260,13 @@ class SimlabAccessor:
 
         for k, v in output_vars.items():
             if k is None or k in self.clock_coords:
+                warnings.warn(
+                    "Setting clock dimensions or `None` as keys for `output_vars`"
+                    " is depreciated; use variable names instead (and clock "
+                    "dimensions or `None` as values, see docs).",
+                    FutureWarning,
+                    stacklevel=2,
+                )
                 o_vars.update({vn: k for vn in _flatten_outputs({k: v})[k]})
 
             else:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #78
 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

TODO: 

 - [x] add `FutureWarning` when clock dimension are given as keys for ``output_vars``.