### PR TITLE
Update docstring with original description of foreign variables

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,6 +68,8 @@ Enhancements
   Docstring can be placed arbitrarily by using the placeholder {{attributes}}
   Variable description will be replaced by (no description given) if that field
   is left empty in the process.
+- Docstring now contains original description of foreign variables using
+  `formatting.foreign_var()`
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,6 +47,27 @@ Enhancements
   to :func:`xarray.Dataset.xsimlab.run`.
 - More consistent dictionary format for output variables in the xarray
   extension (:issue:`85`).
+- Existing and newly written processes will be updated automatically
+  (:issue:`3`) now with a docstring that follows the template:
+
+      Attributes
+      ----------
+      var1: object
+          Variable description
+
+          - type: variable
+          - intent: in
+          - dims : ((),)
+          - groups : ()
+          - static : False
+          - attrs : {}
+
+      var2: object
+      ...
+
+  Docstring can be placed arbitrarily by using the placeholder {{attributes}}
+  Variable description will be replaced by (no description given) if that field
+  is left empty in the process.
 
 Bug fixes
 ~~~~~~~~~

--- a/xsimlab/formatting.py
+++ b/xsimlab/formatting.py
@@ -87,6 +87,9 @@ def var_details(var, max_line_length=70):
     description = textwrap.fill(
         var_metadata.pop("description").capitalize(), width=max_line_length
     )
+    if var.metadata.get("var_type").value == "foreign":
+        description = foreign_var(var)
+
     if not description:
         description = "(no description given)"
 
@@ -108,6 +111,7 @@ def add_attribute_section(process, placeholder="{{attributes}}"):
 
     for vname, var in variables_dict(process).items():
         var_header = f"{vname} : {data_type}"
+
         var_content = textwrap.indent(var_details(var, max_line_length=62), " " * 4)
 
         fmt_vars.append(f"{var_header}\n{var_content}")
@@ -124,6 +128,16 @@ def add_attribute_section(process, placeholder="{{attributes}}"):
         new_doc = f"{current_doc}\n{fmt_section}\n"
 
     return new_doc
+
+
+def foreign_var(var):
+    ref_process = var.metadata.get("other_process_cls")
+
+    for key, value in variables_dict(ref_process).items():
+        if key == var.metadata.get("var_name"):
+            var_data = value.metadata.get("description")
+
+    return var_data
 
 
 def repr_process(process):

--- a/xsimlab/formatting.py
+++ b/xsimlab/formatting.py
@@ -81,14 +81,14 @@ def _summarize_var(var, process, col_width):
     return left_col + right_col
 
 
-def var_details(var):
-    max_line_length = 70
-
+def var_details(var, max_line_length=70):
     var_metadata = var.metadata.copy()
 
     description = textwrap.fill(
         var_metadata.pop("description").capitalize(), width=max_line_length
     )
+    if not description:
+        description = "(no description given)"
 
     detail_items = [
         ("type", var_metadata.pop("var_type").value),
@@ -99,6 +99,31 @@ def var_details(var):
     details = "\n".join(["- {} : {}".format(k, v) for k, v in detail_items])
 
     return description + "\n\n" + details + "\n"
+
+
+def add_attribute_section(process, placeholder="{{attributes}}"):
+    data_type = "object"  # placeholder until issue #34 is solved
+
+    fmt_vars = []
+
+    for vname, var in variables_dict(process).items():
+        var_header = f"{vname} : {data_type}"
+        var_content = textwrap.indent(var_details(var, max_line_length=62), " " * 4)
+
+        fmt_vars.append(f"{var_header}\n{var_content}")
+
+    fmt_section = textwrap.indent(
+        "Attributes\n" "----------\n" + "\n".join(fmt_vars), " " * 4
+    )
+
+    current_doc = process.__doc__ or ""
+
+    if placeholder in current_doc:
+        new_doc = current_doc.replace(placeholder, fmt_section[4:])
+    else:
+        new_doc = f"{current_doc}\n{fmt_section}\n"
+
+    return new_doc
 
 
 def repr_process(process):

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -7,7 +7,7 @@ import warnings
 import attr
 
 from .variable import VarIntent, VarType
-from .formatting import repr_process, var_details
+from .formatting import add_attribute_section, repr_process, var_details
 from .utils import has_method, variables_dict
 
 
@@ -474,8 +474,9 @@ class _ProcessBuilder:
                 self._p_cls_dict[var_name] = make_prop_func(var)
 
     def render_docstrings(self):
-        # self._p_cls_dict['__doc__'] = "Process-ified class."
-        raise NotImplementedError("autodoc is not yet implemented.")
+        new_doc = add_attribute_section(self._base_cls)
+
+        self._base_cls.__doc__ = new_doc
 
     def build_class(self):
         p_cls = self._make_process_subclass()
@@ -487,7 +488,7 @@ class _ProcessBuilder:
         return p_cls
 
 
-def process(maybe_cls=None, autodoc=False):
+def process(maybe_cls=None, autodoc=True):
     """A class decorator that adds everything needed to use the class
     as a process.
 
@@ -515,7 +516,25 @@ def process(maybe_cls=None, autodoc=False):
         ``@process(*args)``.
     autodoc : bool, optional
         If True, render the docstrings template and fill the
-        corresponding sections with variable metadata (default: False).
+        corresponding sections with variable metadata (default: True).
+        {{attributes}} can be used as a placeholder for the updated
+        metadata information.
+        
+        Docstring template:
+            Attributes
+            ----------
+            var1: object
+                Variable description
+
+                - type: variable
+                - intent: in
+                - dims : ((),)
+                - groups : ()
+                - static : False
+                - attrs : {}
+                
+            var2: object
+            ...
 
     """
 

--- a/xsimlab/tests/test_formatting.py
+++ b/xsimlab/tests/test_formatting.py
@@ -2,6 +2,7 @@ from textwrap import dedent
 
 import xsimlab as xs
 from xsimlab.formatting import (
+    add_attribute_section,
     maybe_truncate,
     pretty_print,
     repr_process,
@@ -40,6 +41,58 @@ def test_var_details(example_process_obj):
     assert "- type : variable" in var_details_str
     assert "- intent : in" in var_details_str
     assert "- dims : (('x',),)" in var_details_str
+
+
+def test_add_attribute_section():
+    @xs.process(autodoc=False)
+    class Dummy:
+        """This is a Dummy class
+    to test `add_attribute_section()`
+        """
+
+        var1 = xs.variable(dims="x", description="a variable")
+        var2 = xs.variable()
+
+    @xs.process(autodoc=False)
+    class Dummy_placeholder:
+        """This is a Dummy class
+    to test `add_attribute_section()`
+        
+    {{attributes}}
+"""
+
+        var1 = xs.variable(dims="x", description="a variable")
+        var2 = xs.variable()
+
+    expected = """This is a Dummy class
+    to test `add_attribute_section()`
+        
+    Attributes
+    ----------
+    var1 : object
+        A variable
+
+        - type : variable
+        - intent : in
+        - dims : (('x',),)
+        - groups : ()
+        - static : False
+        - attrs : {}
+
+    var2 : object
+        (no description given)
+
+        - type : variable
+        - intent : in
+        - dims : ((),)
+        - groups : ()
+        - static : False
+        - attrs : {}
+
+"""
+
+    assert add_attribute_section(Dummy) == expected
+    assert add_attribute_section(Dummy_placeholder) == expected
 
 
 def test_process_repr(

--- a/xsimlab/tests/test_formatting.py
+++ b/xsimlab/tests/test_formatting.py
@@ -95,6 +95,48 @@ def test_add_attribute_section():
     assert add_attribute_section(Dummy_placeholder) == expected
 
 
+def test_foreign_var():
+    @xs.process(autodoc=False)
+    class OriProcess:
+        """Original Process"""
+
+        some_var = xs.variable(
+            groups="some_group", intent="out", description="original description"
+        )
+
+    @xs.process(autodoc=False)
+    class RefProcess:
+        """Referencing Process"""
+
+        another_var = xs.variable()
+        some_foreign_var = xs.foreign(OriProcess, "some_var")
+
+    expected = """Referencing Process
+    Attributes
+    ----------
+    another_var : object
+        (no description given)
+
+        - type : variable
+        - intent : in
+        - dims : ((),)
+        - groups : ()
+        - static : False
+        - attrs : {}
+
+    some_foreign_var : object
+        original description
+
+        - type : foreign
+        - intent : in
+        - other_process_cls : <class 'xsimlab.tests.test_formatting.test_foreign_var.<locals>.OriProcess'>
+        - var_name : some_var
+
+"""
+
+    assert add_attribute_section(RefProcess) == expected
+
+
 def test_process_repr(
     example_process_obj,
     processes_with_store,

--- a/xsimlab/tests/test_process.py
+++ b/xsimlab/tests/test_process.py
@@ -251,11 +251,16 @@ def test_process_executor_raise():
 
 
 def test_process_decorator():
-    with pytest.raises(NotImplementedError):
+    @xs.process(autodoc=True)
+    class Dummy_t:
+        pass
 
-        @xs.process(autodoc=True)
-        class Dummy:
-            pass
+    @xs.process(autodoc=False)
+    class Dummy_f:
+        pass
+
+    assert "Attributes" in Dummy_t.__doc__
+    assert Dummy_f.__doc__ is None
 
 
 def test_process_no_model():


### PR DESCRIPTION
This little addition replaces the `Reference to variable 'some var' defined in class 'some class'` in the docstring with the given description in the original process.

 - [x] Extends [PR#67-Automatically generate Docstring](https://github.com/benbovy/xarray-simlab/pull/67)
 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes
