### PR TITLE
Converted old string formatting to fstrings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,30 +19,30 @@
 import sys
 import os
 
-print("python exec:", sys.executable)
-print("sys.path:", sys.path)
+print(f"python exec: {sys.executable}")
+print(f"sys.path: {sys.path}")
 try:
     import numpy
 
-    print("numpy: %s, %s" % (numpy.__version__, numpy.__file__))
+    print(f"numpy: {numpy.__version__}, {numpy.__file__}")
 except ImportError:
     print("no numpy")
 try:
     import attr
 
-    print("attr: %s, %s" % (attr.__version__, attr.__file__))
+    print(f"attr: {attr.__version__}, {attr.__file__}")
 except ImportError:
     print("no attr")
 try:
     import xarray
 
-    print("xarray: %s, %s" % (xarray.__version__, xarray.__file__))
+    print(f"xarray: {xarray.__version__}, {xarray.__file__}")
 except ImportError:
     print("no xarray")
 
 import xsimlab
 
-print("xsimlab: %s, %s" % (xsimlab.__version__, xsimlab.__file__))
+print(f"xsimlab: {xsimlab.__version__}, {xsimlab.__file__}")
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,8 +47,8 @@ Enhancements
   to :func:`xarray.Dataset.xsimlab.run`.
 - More consistent dictionary format for output variables in the xarray
   extension (:issue:`85`).
-- %-formatting and str.format() has been converted into formatted string
-  literals (f-strings)
+- %-formatting and str.format() code has been converted into formatted string
+  literals (f-strings) (:issue:`80`).
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,6 +47,8 @@ Enhancements
   to :func:`xarray.Dataset.xsimlab.run`.
 - More consistent dictionary format for output variables in the xarray
   extension (:issue:`85`).
+- %-formatting and str.format() has been converted into formatted string
+  literals (f-strings)
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -48,7 +48,7 @@ Enhancements
 - More consistent dictionary format for output variables in the xarray
   extension (:issue:`85`).
 - %-formatting and str.format() code has been converted into formatted string
-  literals (f-strings) (:issue:`80`).
+  literals (f-strings) (:issue:`90`).
 
 Bug fixes
 ~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     keywords="python xarray modelling simulation framework",
     packages=find_packages(),
     long_description=(open("README.rst").read() if exists("README.rst") else ""),
-    python_requires=">=3.6",
+    python_requires=">=3.5",
     install_requires=["attrs >= 18.1.0", "numpy", "xarray >= 0.10.0"],
     tests_require=["pytest >= 3.3.0"],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     keywords="python xarray modelling simulation framework",
     packages=find_packages(),
     long_description=(open("README.rst").read() if exists("README.rst") else ""),
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=["attrs >= 18.1.0", "numpy", "xarray >= 0.10.0"],
     tests_require=["pytest >= 3.3.0"],
     zip_safe=False,

--- a/versioneer.py
+++ b/versioneer.py
@@ -1015,7 +1015,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # "stabilization", as well as "HEAD" and "master".
         tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs - tags))
+            print(f"discarding '{','.join(refs - tags)}', no digits")
     if verbose:
         print(f"likely tags: {','.join(sorted(tags))}")
     for ref in sorted(tags):

--- a/versioneer.py
+++ b/versioneer.py
@@ -1826,7 +1826,7 @@ def do_setup():
             "to MANIFEST.in"
         )
         with open(manifest_in, "a") as f:
-            f.write("include %s\n" % cfg.versionfile_source)
+            f.write(f"include {cfg.versionfile_source}\n")
     else:
         print(" versionfile_source already in MANIFEST.in")
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -1115,7 +1115,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         if not full_tag.startswith(tag_prefix):
             if verbose:
                 print(f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'")
-            pieces["error"] = f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'"
+            pieces[
+                "error"
+            ] = f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'"
             return pieces
         pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
@@ -1253,7 +1255,7 @@ def write_to_version_file(filename, versions):
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
-    print(f"set {filename} to '{versions["version"]}'")
+    print(f"set {filename} to {versions['version']!r}")
 
 
 def plus_or_dot(pieces):
@@ -1555,12 +1557,12 @@ def get_cmdclass():
 
         def run(self):
             vers = get_versions(verbose=True)
-            print(f"Version: {vers["version"]}")
-            print(f" full-revisionid: {vers.get("full-revisionid")}")
-            print(f" dirty: {vers.get("dirty")}")
-            print(f" date: {vers.get("date")}")
+            print(f"Version: {vers['version']}")
+            print(f" full-revisionid: {vers.get('full-revisionid')}")
+            print(f" dirty: {vers.get('dirty')}")
+            print(f" date: {vers.get('date')}")
             if vers["error"]:
-                print(f" error: {vers["error"]}")
+                print(f" error: {vers['error']}")
 
     cmds["version"] = cmd_version
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -328,8 +328,8 @@ def get_root():
         vsr_dir = os.path.normcase(os.path.splitext(versioneer_py)[0])
         if me_dir != vsr_dir:
             print(
-                "Warning: build in %s is using versioneer.py from %s"
-                % (os.path.dirname(me), versioneer_py)
+                f"Warning: build in {os.path.dirname(me)} is "
+                f"using versioneer.py from {versioneer_py}"
             )
     except NameError:
         pass
@@ -409,20 +409,20 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
             if e.errno == errno.ENOENT:
                 continue
             if verbose:
-                print("unable to run %s" % dispcmd)
+                print(f"unable to run {dispcmd}")
                 print(e)
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print(f"unable to find command, tried {commands}")
         return None, None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
         stdout = stdout.decode()
     if p.returncode != 0:
         if verbose:
-            print("unable to run %s (error)" % dispcmd)
-            print("stdout was %s" % stdout)
+            print(f"unable to run {dispcmd} (error)")
+            print(f"stdout was {stdout}")
         return None, p.returncode
     return stdout, p.returncode
 
@@ -1017,13 +1017,13 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
-        print("likely tags: %s" % ",".join(sorted(tags)))
+        print(f"likely tags: {','.join(sorted(tags))}")
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix) :]
             if verbose:
-                print("picking %s" % r)
+                print(f"picking {r}")
             return {
                 "version": r,
                 "full-revisionid": keywords["full"].strip(),
@@ -1058,7 +1058,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
-            print("Directory %s not under git control" % root)
+            print(f"Directory {root} not under git control")
         raise NotThisMethod("'git rev-parse --git-dir' returned error")
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
@@ -1072,7 +1072,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             "--always",
             "--long",
             "--match",
-            "%s*" % tag_prefix,
+            f"{tag_prefix}*",
         ],
         cwd=root,
     )
@@ -1107,19 +1107,15 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
+            pieces["error"] = f"unable to parse git-describe output: '{describe_out}'"
             return pieces
 
         # tag
         full_tag = mo.group(1)
         if not full_tag.startswith(tag_prefix):
             if verbose:
-                fmt = "tag '%s' doesn't start with prefix '%s'"
-                print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
-                full_tag,
-                tag_prefix,
-            )
+                print(f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'")
+            pieces["error"] = f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'"
             return pieces
         pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
@@ -1176,7 +1172,7 @@ def do_vcs_install(manifest_in, versionfile_source, ipy):
         pass
     if not present:
         f = open(".gitattributes", "a+")
-        f.write("%s export-subst\n" % versionfile_source)
+        f.write(f"{versionfile_source} export-subst\n")
         f.close()
         files.append(".gitattributes")
     run_command(GITS, ["add", "--"] + files)
@@ -1207,8 +1203,8 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
 
     if verbose:
         print(
-            "Tried directories %s but none started with prefix %s"
-            % (str(rootdirs), parentdir_prefix)
+            f"Tried directories {str(rootdirs)} but none "
+            f"started with prefix {parentdir_prefix}"
         )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
@@ -1257,7 +1253,7 @@ def write_to_version_file(filename, versions):
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
-    print("set %s to '%s'" % (filename, versions["version"]))
+    print(f"set {filename} to '{versions["version"]}'")
 
 
 def plus_or_dot(pieces):
@@ -1280,12 +1276,12 @@ def render_pep440(pieces):
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
             rendered += plus_or_dot(pieces)
-            rendered += "%d.g%s" % (pieces["distance"], pieces["short"])
+            rendered += f"{pieces["distance"]:d}.g{pieces["short"]}"
             if pieces["dirty"]:
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
+        rendered = f"0+untagged.{pieces["distance"]:d}.g{pieces["short"]}"
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -1300,10 +1296,10 @@ def render_pep440_pre(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += ".post.dev%d" % pieces["distance"]
+            rendered += f".post.dev{pieces["distance"]:d}"
     else:
         # exception #1
-        rendered = "0.post.dev%d" % pieces["distance"]
+        rendered = f"0.post.dev{pieces["distance"]:d}"
     return rendered
 
 
@@ -1320,17 +1316,17 @@ def render_pep440_post(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += ".post%d" % pieces["distance"]
+            rendered += f".post{pieces["distance"]:d}"
             if pieces["dirty"]:
                 rendered += ".dev0"
             rendered += plus_or_dot(pieces)
-            rendered += "g%s" % pieces["short"]
+            rendered += f"g{pieces["short"]}"
     else:
         # exception #1
-        rendered = "0.post%d" % pieces["distance"]
+        rendered = f"0.post{pieces["distance"]:d}"
         if pieces["dirty"]:
             rendered += ".dev0"
-        rendered += "+g%s" % pieces["short"]
+        rendered += f"+g{pieces["short"]}"
     return rendered
 
 
@@ -1345,12 +1341,12 @@ def render_pep440_old(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += ".post%d" % pieces["distance"]
+            rendered += f".post{pieces["distance"]:d}"
             if pieces["dirty"]:
                 rendered += ".dev0"
     else:
         # exception #1
-        rendered = "0.post%d" % pieces["distance"]
+        rendered = f"0.post{pieces["distance"]:d}"
         if pieces["dirty"]:
             rendered += ".dev0"
     return rendered
@@ -1367,7 +1363,7 @@ def render_git_describe(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])
+            rendered += f"-{pieces["distance"]:d}-g{pieces["short"]}"
     else:
         # exception #1
         rendered = pieces["short"]
@@ -1387,7 +1383,7 @@ def render_git_describe_long(pieces):
     """
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
-        rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])
+        rendered += f"-{pieces["distance"]:d}-g{pieces["short"]}"
     else:
         # exception #1
         rendered = pieces["short"]
@@ -1423,7 +1419,7 @@ def render(pieces, style):
     elif style == "git-describe-long":
         rendered = render_git_describe_long(pieces)
     else:
-        raise ValueError("unknown style '%s'" % style)
+        raise ValueError(f"unknown style '{style}'")
 
     return {
         "version": rendered,
@@ -1452,7 +1448,7 @@ def get_versions(verbose=False):
 
     assert cfg.VCS is not None, "please set [versioneer]VCS= in setup.cfg"
     handlers = HANDLERS.get(cfg.VCS)
-    assert handlers, "unrecognized VCS '%s'" % cfg.VCS
+    assert handlers, f"unrecognized VCS '{cfg.VCS}'"
     verbose = verbose or cfg.verbose
     assert (
         cfg.versionfile_source is not None
@@ -1474,7 +1470,7 @@ def get_versions(verbose=False):
             keywords = get_keywords_f(versionfile_abs)
             ver = from_keywords_f(keywords, cfg.tag_prefix, verbose)
             if verbose:
-                print("got version from expanded keyword %s" % ver)
+                print(f"got version from expanded keyword {ver}")
             return ver
         except NotThisMethod:
             pass
@@ -1482,7 +1478,7 @@ def get_versions(verbose=False):
     try:
         ver = versions_from_file(versionfile_abs)
         if verbose:
-            print("got version from file %s %s" % (versionfile_abs, ver))
+            print(f"got version from file {versionfile_abs} {ver}")
         return ver
     except NotThisMethod:
         pass
@@ -1493,7 +1489,7 @@ def get_versions(verbose=False):
             pieces = from_vcs_f(cfg.tag_prefix, root, verbose)
             ver = render(pieces, cfg.style)
             if verbose:
-                print("got version from VCS %s" % ver)
+                print(f"got version from VCS {ver}")
             return ver
         except NotThisMethod:
             pass
@@ -1502,7 +1498,7 @@ def get_versions(verbose=False):
         if cfg.parentdir_prefix:
             ver = versions_from_parentdir(cfg.parentdir_prefix, root, verbose)
             if verbose:
-                print("got version from parentdir %s" % ver)
+                print(f"got version from parentdir {ver}")
             return ver
     except NotThisMethod:
         pass
@@ -1559,12 +1555,12 @@ def get_cmdclass():
 
         def run(self):
             vers = get_versions(verbose=True)
-            print("Version: %s" % vers["version"])
-            print(" full-revisionid: %s" % vers.get("full-revisionid"))
-            print(" dirty: %s" % vers.get("dirty"))
-            print(" date: %s" % vers.get("date"))
+            print(f"Version: {vers["version"]}")
+            print(f" full-revisionid: {vers.get("full-revisionid")}")
+            print(f" dirty: {vers.get("dirty")}")
+            print(f" date: {vers.get("date")}")
             if vers["error"]:
-                print(" error: %s" % vers["error"])
+                print(f" error: {vers["error"]}")
 
     cmds["version"] = cmd_version
 
@@ -1599,7 +1595,7 @@ def get_cmdclass():
             # it with an updated value
             if cfg.versionfile_build:
                 target_versionfile = os.path.join(self.build_lib, cfg.versionfile_build)
-                print("UPDATING %s" % target_versionfile)
+                print(f"UPDATING {target_versionfile}")
                 write_to_version_file(target_versionfile, versions)
 
     cmds["build_py"] = cmd_build_py
@@ -1620,7 +1616,7 @@ def get_cmdclass():
                 cfg = get_config_from_root(root)
                 versions = get_versions()
                 target_versionfile = cfg.versionfile_source
-                print("UPDATING %s" % target_versionfile)
+                print(f"UPDATING {target_versionfile}")
                 write_to_version_file(target_versionfile, versions)
 
                 _build_exe.run(self)
@@ -1653,7 +1649,7 @@ def get_cmdclass():
                 cfg = get_config_from_root(root)
                 versions = get_versions()
                 target_versionfile = cfg.versionfile_source
-                print("UPDATING %s" % target_versionfile)
+                print(f"UPDATING {target_versionfile}")
                 write_to_version_file(target_versionfile, versions)
 
                 _py2exe.run(self)
@@ -1696,7 +1692,7 @@ def get_cmdclass():
             # (remembering that it may be a hardlink) and replace it with an
             # updated value
             target_versionfile = os.path.join(base_dir, cfg.versionfile_source)
-            print("UPDATING %s" % target_versionfile)
+            print(f"UPDATING {target_versionfile}")
             write_to_version_file(
                 target_versionfile, self._versioneer_generated_versions
             )
@@ -1767,7 +1763,7 @@ def do_setup():
         print(CONFIG_ERROR, file=sys.stderr)
         return 1
 
-    print(" creating %s" % cfg.versionfile_source)
+    print(f" creating {cfg.versionfile_source}")
     with open(cfg.versionfile_source, "w") as f:
         LONG = LONG_VERSION_PY[cfg.VCS]
         f.write(
@@ -1789,13 +1785,13 @@ def do_setup():
         except EnvironmentError:
             old = ""
         if INIT_PY_SNIPPET not in old:
-            print(" appending to %s" % ipy)
+            print(f" appending to {ipy}")
             with open(ipy, "a") as f:
                 f.write(INIT_PY_SNIPPET)
         else:
-            print(" %s unmodified" % ipy)
+            print(f" {ipy} unmodified")
     else:
-        print(" %s doesn't exist, ok" % ipy)
+        print(f" {ipy} doesn't exist, ok")
         ipy = None
 
     # Make sure both the top-level "versioneer.py" and versionfile_source
@@ -1824,8 +1820,8 @@ def do_setup():
         print(" 'versioneer.py' already in MANIFEST.in")
     if cfg.versionfile_source not in simple_includes:
         print(
-            " appending versionfile_source ('%s') to MANIFEST.in"
-            % cfg.versionfile_source
+            f" appending versionfile_source ('{cfg.versionfile_source}') "
+            "to MANIFEST.in"
         )
         with open(manifest_in, "a") as f:
             f.write("include %s\n" % cfg.versionfile_source)

--- a/versioneer.py
+++ b/versioneer.py
@@ -1276,12 +1276,12 @@ def render_pep440(pieces):
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
             rendered += plus_or_dot(pieces)
-            rendered += f"{pieces["distance"]:d}.g{pieces["short"]}"
+            rendered += f"{pieces['distance']:d}.g{pieces['short']}"
             if pieces["dirty"]:
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = f"0+untagged.{pieces["distance"]:d}.g{pieces["short"]}"
+        rendered = f"0+untagged.{pieces['distance']:d}.g{pieces['short']}"
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -1296,10 +1296,10 @@ def render_pep440_pre(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += f".post.dev{pieces["distance"]:d}"
+            rendered += f".post.dev{pieces['distance']:d}"
     else:
         # exception #1
-        rendered = f"0.post.dev{pieces["distance"]:d}"
+        rendered = f"0.post.dev{pieces['distance']:d}"
     return rendered
 
 
@@ -1316,17 +1316,17 @@ def render_pep440_post(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += f".post{pieces["distance"]:d}"
+            rendered += f".post{pieces['distance']:d}"
             if pieces["dirty"]:
                 rendered += ".dev0"
             rendered += plus_or_dot(pieces)
-            rendered += f"g{pieces["short"]}"
+            rendered += f"g{pieces['short']}"
     else:
         # exception #1
-        rendered = f"0.post{pieces["distance"]:d}"
+        rendered = f"0.post{pieces['distance']:d}"
         if pieces["dirty"]:
             rendered += ".dev0"
-        rendered += f"+g{pieces["short"]}"
+        rendered += f"+g{pieces['short']}"
     return rendered
 
 
@@ -1341,12 +1341,12 @@ def render_pep440_old(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += f".post{pieces["distance"]:d}"
+            rendered += f".post{pieces['distance']:d}"
             if pieces["dirty"]:
                 rendered += ".dev0"
     else:
         # exception #1
-        rendered = f"0.post{pieces["distance"]:d}"
+        rendered = f"0.post{pieces['distance']:d}"
         if pieces["dirty"]:
             rendered += ".dev0"
     return rendered
@@ -1363,7 +1363,7 @@ def render_git_describe(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += f"-{pieces["distance"]:d}-g{pieces["short"]}"
+            rendered += f"-{pieces['distance']:d}-g{pieces['short']}"
     else:
         # exception #1
         rendered = pieces["short"]
@@ -1383,7 +1383,7 @@ def render_git_describe_long(pieces):
     """
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
-        rendered += f"-{pieces["distance"]:d}-g{pieces["short"]}"
+        rendered += f"-{pieces['distance']:d}-g{pieces['short']}"
     else:
         # exception #1
         rendered = pieces["short"]

--- a/xsimlab/_version.py
+++ b/xsimlab/_version.py
@@ -301,7 +301,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         if not full_tag.startswith(tag_prefix):
             if verbose:
                 print(f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'")
-            pieces["error"] = f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'"
+            pieces[
+                "error"
+            ] = f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'"
             return pieces
         pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 

--- a/xsimlab/_version.py
+++ b/xsimlab/_version.py
@@ -201,7 +201,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # "stabilization", as well as "HEAD" and "master".
         tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs - tags))
+            print(f"discarding '{','.join(refs - tags)}', no digits")
     if verbose:
         print(f"likely tags: {','.join(sorted(tags))}")
     for ref in sorted(tags):

--- a/xsimlab/_version.py
+++ b/xsimlab/_version.py
@@ -346,12 +346,12 @@ def render_pep440(pieces):
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
             rendered += plus_or_dot(pieces)
-            rendered += f"{pieces["distance"]:d}.g{pieces["short"]}"
+            rendered += f"{pieces['distance']:d}.g{pieces['short']}"
             if pieces["dirty"]:
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = f"0+untagged.{pieces["distance"]:d}.g{pieces["short"]}"
+        rendered = f"0+untagged.{pieces['distance']:d}.g{pieces['short']}"
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -366,10 +366,10 @@ def render_pep440_pre(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += f".post.dev{pieces["distance"]:d}"
+            rendered += f".post.dev{pieces['distance']:d}"
     else:
         # exception #1
-        rendered = f"0.post.dev{pieces["distance"]:d}"
+        rendered = f"0.post.dev{pieces['distance']:d}"
     return rendered
 
 
@@ -386,17 +386,17 @@ def render_pep440_post(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += f".post{pieces["distance"]:d}"
+            rendered += f".post{pieces['distance']:d}"
             if pieces["dirty"]:
                 rendered += ".dev0"
             rendered += plus_or_dot(pieces)
-            rendered += f"g{pieces["short"]}"
+            rendered += f"g{pieces['short']}"
     else:
         # exception #1
-        rendered = f"0.post{pieces["distance"]:d}"
+        rendered = f"0.post{pieces['distance']:d}"
         if pieces["dirty"]:
             rendered += ".dev0"
-        rendered += f"+g{pieces["short"]}"
+        rendered += f"+g{pieces['short']}"
     return rendered
 
 
@@ -411,12 +411,12 @@ def render_pep440_old(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += f".post{pieces["distance"]:d}"
+            rendered += f".post{pieces['distance']:d}"
             if pieces["dirty"]:
                 rendered += ".dev0"
     else:
         # exception #1
-        rendered = f"0.post{pieces["distance"]:d}"
+        rendered = f"0.post{pieces['distance']:d}"
         if pieces["dirty"]:
             rendered += ".dev0"
     return rendered
@@ -433,7 +433,7 @@ def render_git_describe(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += f"-{pieces["distance"]:d}-g{pieces["short"]}"
+            rendered += f"-{pieces['distance']:d}-g{pieces['short']}"
     else:
         # exception #1
         rendered = pieces["short"]
@@ -453,7 +453,7 @@ def render_git_describe_long(pieces):
     """
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
-        rendered += f"-{pieces["distance"]:d}-g{pieces["short"]}"
+        rendered += f"-{pieces['distance']:d}-g{pieces['short']}"
     else:
         # exception #1
         rendered = pieces["short"]

--- a/xsimlab/_version.py
+++ b/xsimlab/_version.py
@@ -244,7 +244,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
-            print("Directory %s not under git control" % root)
+            print(f"Directory {root} not under git control")
         raise NotThisMethod("'git rev-parse --git-dir' returned error")
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]

--- a/xsimlab/_version.py
+++ b/xsimlab/_version.py
@@ -89,20 +89,20 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
             if e.errno == errno.ENOENT:
                 continue
             if verbose:
-                print("unable to run %s" % dispcmd)
+                print(f"unable to run {dispcmd}")
                 print(e)
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print(f"unable to find command, tried {commands}")
         return None, None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
         stdout = stdout.decode()
     if p.returncode != 0:
         if verbose:
-            print("unable to run %s (error)" % dispcmd)
-            print("stdout was %s" % stdout)
+            print(f"unable to run {dispcmd} (error)")
+            print(f"stdout was {stdout}")
         return None, p.returncode
     return stdout, p.returncode
 
@@ -132,8 +132,8 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
 
     if verbose:
         print(
-            "Tried directories %s but none started with prefix %s"
-            % (str(rootdirs), parentdir_prefix)
+            f"Tried directories {str(rootdirs)} but none "
+            f"started with prefix {parentdir_prefix}"
         )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
@@ -203,13 +203,13 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
-        print("likely tags: %s" % ",".join(sorted(tags)))
+        print(f"likely tags: {','.join(sorted(tags))}")
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix) :]
             if verbose:
-                print("picking %s" % r)
+                print(f"picking {r}")
             return {
                 "version": r,
                 "full-revisionid": keywords["full"].strip(),
@@ -258,7 +258,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             "--always",
             "--long",
             "--match",
-            "%s*" % tag_prefix,
+            f"{tag_prefix}*",
         ],
         cwd=root,
     )
@@ -293,19 +293,15 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
+            pieces["error"] = f"unable to parse git-describe output: '{describe_out}'"
             return pieces
 
         # tag
         full_tag = mo.group(1)
         if not full_tag.startswith(tag_prefix):
             if verbose:
-                fmt = "tag '%s' doesn't start with prefix '%s'"
-                print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
-                full_tag,
-                tag_prefix,
-            )
+                print(f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'")
+            pieces["error"] = f"tag '{full_tag}' doesn't start with prefix '{tag_prefix}'"
             return pieces
         pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
@@ -350,12 +346,12 @@ def render_pep440(pieces):
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
             rendered += plus_or_dot(pieces)
-            rendered += "%d.g%s" % (pieces["distance"], pieces["short"])
+            rendered += f"{pieces["distance"]:d}.g{pieces["short"]}"
             if pieces["dirty"]:
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
+        rendered = f"0+untagged.{pieces["distance"]:d}.g{pieces["short"]}"
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -370,10 +366,10 @@ def render_pep440_pre(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += ".post.dev%d" % pieces["distance"]
+            rendered += f".post.dev{pieces["distance"]:d}"
     else:
         # exception #1
-        rendered = "0.post.dev%d" % pieces["distance"]
+        rendered = f"0.post.dev{pieces["distance"]:d}"
     return rendered
 
 
@@ -390,17 +386,17 @@ def render_pep440_post(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += ".post%d" % pieces["distance"]
+            rendered += f".post{pieces["distance"]:d}"
             if pieces["dirty"]:
                 rendered += ".dev0"
             rendered += plus_or_dot(pieces)
-            rendered += "g%s" % pieces["short"]
+            rendered += f"g{pieces["short"]}"
     else:
         # exception #1
-        rendered = "0.post%d" % pieces["distance"]
+        rendered = f"0.post{pieces["distance"]:d}"
         if pieces["dirty"]:
             rendered += ".dev0"
-        rendered += "+g%s" % pieces["short"]
+        rendered += f"+g{pieces["short"]}"
     return rendered
 
 
@@ -415,12 +411,12 @@ def render_pep440_old(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += ".post%d" % pieces["distance"]
+            rendered += f".post{pieces["distance"]:d}"
             if pieces["dirty"]:
                 rendered += ".dev0"
     else:
         # exception #1
-        rendered = "0.post%d" % pieces["distance"]
+        rendered = f"0.post{pieces["distance"]:d}"
         if pieces["dirty"]:
             rendered += ".dev0"
     return rendered
@@ -437,7 +433,7 @@ def render_git_describe(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])
+            rendered += f"-{pieces["distance"]:d}-g{pieces["short"]}"
     else:
         # exception #1
         rendered = pieces["short"]
@@ -457,7 +453,7 @@ def render_git_describe_long(pieces):
     """
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
-        rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])
+        rendered += f"-{pieces["distance"]:d}-g{pieces["short"]}"
     else:
         # exception #1
         rendered = pieces["short"]
@@ -493,7 +489,7 @@ def render(pieces, style):
     elif style == "git-describe-long":
         rendered = render_git_describe_long(pieces)
     else:
-        raise ValueError("unknown style '%s'" % style)
+        raise ValueError(f"unknown style '{style}'")
 
     return {
         "version": rendered,

--- a/xsimlab/dot.py
+++ b/xsimlab/dot.py
@@ -201,7 +201,7 @@ def _get_display_cls(format):
     elif format == "svg":
         return display.SVG
     else:
-        raise ValueError("Unknown format '%s' passed to `dot_graph`" % format)
+        raise ValueError(f"Unknown format '{format}' passed to `dot_graph`")
 
 
 def dot_graph(

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -46,9 +46,8 @@ class RuntimeContext(Mapping):
     def __setitem__(self, key, value):
         if key not in self._context_keys:
             raise KeyError(
-                "Invalid key {!r}, should be one of {!r}".format(
-                    key, self._context_keys
-                )
+                f"Invalid key {key!r}, "
+                f"should be one of {self._context_keys!r}"
             )
 
         self._context[key] = value
@@ -96,10 +95,9 @@ class BaseSimulationDriver:
 
             if check_static and var.metadata.get("static", False):
                 raise RuntimeError(
-                    "Cannot set value in store for "
-                    "static variable {!r} defined "
-                    "in process {!r}".format(var_name, p_name)
-                )
+                    f"Cannot set value in store for "
+                    f"static variable {var_name!r} defined "
+                    f"in process {p_name!r}")
 
             self.store[key] = copy.copy(value)
 
@@ -233,7 +231,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
                 missing_xr_vars.append(xr_var_name)
 
         if missing_xr_vars:
-            raise KeyError("Missing variables %s in Dataset" % missing_xr_vars)
+            raise KeyError(f"Missing variables {missing_xr_vars} in Dataset")
 
     def _get_output_save_steps(self):
         """Returns a dictionary where keys are names of clock coordinates and
@@ -271,11 +269,9 @@ class XarraySimulationDriver(BaseSimulationDriver):
 
         if (strict or transpose) and xr_var.dims not in dims:
             raise ValueError(
-                "Invalid dimension(s) for variable '{}__{}': "
-                "found {!r}, must be one of {}".format(
-                    p_name, var_name, xr_var.dims, ",".join([str(d) for d in dims]),
-                )
-            )
+                f"Invalid dimension(s) for variable '{p_name}__{var_name}': "
+                f"found {xr_var.dims!r}, "
+                f"must be one of {','.join([str(d) for d in dims])}")
 
         return xr_var
 

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -46,8 +46,7 @@ class RuntimeContext(Mapping):
     def __setitem__(self, key, value):
         if key not in self._context_keys:
             raise KeyError(
-                f"Invalid key {key!r}, "
-                f"should be one of {self._context_keys!r}"
+                f"Invalid key {key!r}, " f"should be one of {self._context_keys!r}"
             )
 
         self._context[key] = value
@@ -97,7 +96,8 @@ class BaseSimulationDriver:
                 raise RuntimeError(
                     "Cannot set value in store for "
                     f"static variable {var_name!r} defined "
-                    f"in process {p_name!r}")
+                    f"in process {p_name!r}"
+                )
 
             self.store[key] = copy.copy(value)
 
@@ -271,7 +271,8 @@ class XarraySimulationDriver(BaseSimulationDriver):
             raise ValueError(
                 f"Invalid dimension(s) for variable '{p_name}__{var_name}': "
                 f"found {xr_var.dims!r}, "
-                f"must be one of {','.join([str(d) for d in dims])}")
+                f"must be one of {','.join([str(d) for d in dims])}"
+            )
 
         return xr_var
 

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -46,7 +46,7 @@ class RuntimeContext(Mapping):
     def __setitem__(self, key, value):
         if key not in self._context_keys:
             raise KeyError(
-                f"Invalid key {key!r}, " f"should be one of {self._context_keys!r}"
+                f"Invalid key {key!r}, should be one of {self._context_keys!r}"
             )
 
         self._context[key] = value

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -95,7 +95,7 @@ class BaseSimulationDriver:
 
             if check_static and var.metadata.get("static", False):
                 raise RuntimeError(
-                    f"Cannot set value in store for "
+                    "Cannot set value in store for "
                     f"static variable {var_name!r} defined "
                     f"in process {p_name!r}")
 

--- a/xsimlab/formatting.py
+++ b/xsimlab/formatting.py
@@ -50,7 +50,7 @@ def _summarize_var(var, process, col_width):
         var_intent_str = "[inout]"
 
     if var_type == VarType.GROUP:
-        var_info = "{} group {!r}".format(link_symbol, var.metadata["group"])
+        var_info = f"{link_symbol} group {var.metadata['group']!r}"
 
     elif var_type == VarType.FOREIGN:
         key = process.__xsimlab_store_keys__.get(var_name)
@@ -62,7 +62,7 @@ def _summarize_var(var, process, col_width):
                 var.metadata["var_name"],
             )
 
-        var_info = "{} {}.{}".format(link_symbol, *key)
+        var_info = f"{link_symbol} {'.'.join(key)}"
 
     else:
         var_dims = " or ".join([str(d) for d in var.metadata["dims"]])
@@ -72,7 +72,7 @@ def _summarize_var(var, process, col_width):
         else:
             var_info = var.metadata["description"]
 
-    left_col = pretty_print("    {}".format(var.name), col_width)
+    left_col = pretty_print(f"    {var.name}", col_width)
 
     right_col = var_intent_str
     if var_info:
@@ -96,7 +96,7 @@ def var_details(var):
     ]
     detail_items += list(var_metadata.items())
 
-    details = "\n".join(["- {} : {}".format(k, v) for k, v in detail_items])
+    details = "\n".join([f"- {k} : {v}" for k, v in detail_items])
 
     return description + "\n\n" + details + "\n"
 
@@ -105,11 +105,11 @@ def repr_process(process):
     process_cls = type(process)
 
     if process.__xsimlab_name__ is not None:
-        process_name = "{!r}".format(process.__xsimlab_name__)
+        process_name = f"{process.__xsimlab_name__!r}"
     else:
         process_name = ""
 
-    header = "<{} {} (xsimlab process)>".format(process_cls.__name__, process_name)
+    header = f"<{process_cls.__name__} {process_name} (xsimlab process)>"
 
     variables = variables_dict(process_cls)
 
@@ -148,8 +148,8 @@ def repr_process(process):
 def repr_model(model):
     n_processes = len(model)
 
-    header = "<xsimlab.Model ({} processes, {} inputs)>".format(
-        n_processes, len(model.input_vars)
+    header = (
+        f"<xsimlab.Model ({n_processes} processes, {len(model.input_vars)} inputs)>"
     )
 
     if not n_processes:

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -119,6 +119,7 @@ class _ModelBuilder:
             elif isinstance(target_p_name, list):
                 raise ValueError(
                     "Process class {!r} required by foreign variable '{}.{}' "
+                    "is used (possibly via one its child classes) by multiple "
                     "processes: {}".format(
                         target_p_cls.__name__,
                         p_name,

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -110,22 +110,18 @@ class _ModelBuilder:
 
             if target_p_name is None:
                 raise KeyError(
-                    "Process class '{}' missing in Model but required "
-                    "by foreign variable '{}' declared in process '{}'".format(
-                        target_p_cls.__name__, var.name, p_name
-                    )
+                    f"Process class '{target_p_cls.__name__}' "
+                     "missing in Model but required "
+                    f"by foreign variable '{var.name}' "
+                    f"declared in process '{p_name}'"
                 )
 
             elif isinstance(target_p_name, list):
                 raise ValueError(
-                    "Process class {!r} required by foreign variable '{}.{}' "
-                    "is used (possibly via one its child classes) by multiple "
-                    "processes: {}".format(
-                        target_p_cls.__name__,
-                        p_name,
-                        var.name,
-                        ", ".join(["{!r}".format(n) for n in target_p_name]),
-                    )
+                    f"Process class {target_p_cls.__name__!r} required "
+                    f"by foreign variable '{p_name}.{var.name}' "
+                    f"is used (possibly via one its child classes) by multiple "
+                    f"processes: {', '.join([f'{n!r}' for n in target_p_name])}"
                 )
 
             store_key, od_key = self._get_var_key(target_p_name, target_var)
@@ -205,7 +201,7 @@ class _ModelBuilder:
                 for k, v in conflicts.items()
             }
             msg = "\n".join(
-                ["'{}.{}' set by: {}".format(*k, v) for k, v in conflicts_str.items()]
+                [f"'{'.'.join(k)}' set by: {v}" for k, v in conflicts_str.items()]
             )
 
             raise ValueError("Conflict(s) found in given variable intents:\n" + msg)
@@ -376,7 +372,7 @@ class _ModelBuilder:
                             cycle.reverse()
                             cycle = "->".join(cycle)
                             raise RuntimeError(
-                                "Cycle detected in process graph: %s" % cycle
+                                f"Cycle detected in process graph: {cycle}"
                             )
                         next_nodes.append(nxt)
 

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -111,7 +111,7 @@ class _ModelBuilder:
             if target_p_name is None:
                 raise KeyError(
                     f"Process class '{target_p_cls.__name__}' "
-                     "missing in Model but required "
+                    "missing in Model but required "
                     f"by foreign variable '{var.name}' "
                     f"declared in process '{p_name}'"
                 )
@@ -120,7 +120,7 @@ class _ModelBuilder:
                 raise ValueError(
                     f"Process class {target_p_cls.__name__!r} required "
                     f"by foreign variable '{p_name}.{var.name}' "
-                    f"is used (possibly via one its child classes) by multiple "
+                    "is used (possibly via one its child classes) by multiple "
                     f"processes: {', '.join([f'{n!r}' for n in target_p_name])}"
                 )
 
@@ -204,7 +204,7 @@ class _ModelBuilder:
                 [f"'{'.'.join(k)}' set by: {v}" for k, v in conflicts_str.items()]
             )
 
-            raise ValueError("Conflict(s) found in given variable intents:\n" + msg)
+            raise ValueError(f"Conflict(s) found in given variable intents:\n{msg}")
 
     def get_all_variables(self):
         """Get all variables in the model as a list of

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -118,10 +118,13 @@ class _ModelBuilder:
 
             elif isinstance(target_p_name, list):
                 raise ValueError(
-                    f"Process class {target_p_cls.__name__!r} required "
-                    f"by foreign variable '{p_name}.{var.name}' "
-                    "is used (possibly via one its child classes) by multiple "
-                    f"processes: {', '.join([f'{n!r}' for n in target_p_name])}"
+                    "Process class {!r} required by foreign variable '{}.{}' "
+                    "processes: {}".format(
+                        target_p_cls.__name__,
+                        p_name,
+                        var.name,
+                        ", ".join(["{!r}".format(n) for n in target_p_name]),
+                    )
                 )
 
             store_key, od_key = self._get_var_key(target_p_name, target_var)

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -30,7 +30,7 @@ def _get_embedded_process_cls(cls):
             return cls.__xsimlab_cls__
         except AttributeError:
             raise NotAProcessClassError(
-                "{cls!r} is not a " "process-decorated class.".format(cls=cls)
+                f"{cls!r} is not a process-decorated class."
             )
 
 
@@ -135,7 +135,7 @@ def get_target_variable(var):
         if (target_process_cls, target_var) in visited:  # pragma: no cover
             cycle = "->".join(
                 [
-                    "{}.{}".format(cls.__name__, var.name)
+                    f"{cls.__name__}.{var.name}"
                     if cls is not None
                     else var.name
                     for cls, var in visited
@@ -143,7 +143,7 @@ def get_target_variable(var):
             )
 
             raise RuntimeError(
-                "Cycle detected in process dependencies: {}".format(cycle)
+                f"Cycle detected in process dependencies: {cycle}"
             )
 
     return target_process_cls, target_var
@@ -191,9 +191,9 @@ def _make_property_variable(var):
 
     if target_type == VarType.GROUP:
         raise ValueError(
-            "Variable {var!r} links to group variable "
-            "{target!r}, which is not supported. Declare {var!r} "
-            "as a group variable instead.".format(var=var.name, target=target_str)
+            f"Variable {var.name!r} links to group variable "
+            f"{target_str!r}, which is not supported. Declare {var.name!r} "
+            "as a group variable instead."
         )
 
     elif (
@@ -202,8 +202,8 @@ def _make_property_variable(var):
         and target_intent == VarIntent.OUT
     ):
         raise ValueError(
-            "Conflict between foreign variable {!r} and its "
-            "target variable {!r}, both have intent='out'.".format(var.name, target_str)
+            f"Conflict between foreign variable {var.name!r} and its "
+            f"target variable {target_str!r}, both have intent='out'."
         )
 
     elif target_type == VarType.ON_DEMAND:

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -133,7 +133,9 @@ def get_target_variable(var):
         if (target_process_cls, target_var) in visited:  # pragma: no cover
             cycle = "->".join(
                 [
-                    f"{cls.__name__}.{var.name}" if cls is not None else var.name
+                    "{}.{}".format(cls.__name__, var.name)
+                    if cls is not None
+                    else var.name
                     for cls, var in visited
                 ]
             )

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -225,8 +225,8 @@ def _make_property_on_demand(var):
     if "compute" not in var.metadata:
         raise KeyError(
             "No compute method found for on_demand variable "
-            "'{name}'. A method decorated with '@{name}.compute' "
-            "is required in the class definition.".format(name=var.name)
+            f"'{var.name}'. A method decorated with '@{var.name}.compute' "
+            "is required in the class definition."
         )
 
     get_method = var.metadata["compute"]

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -29,9 +29,7 @@ def _get_embedded_process_cls(cls):
         try:
             return cls.__xsimlab_cls__
         except AttributeError:
-            raise NotAProcessClassError(
-                f"{cls!r} is not a process-decorated class."
-            )
+            raise NotAProcessClassError(f"{cls!r} is not a process-decorated class.")
 
 
 def get_process_cls(obj_or_cls):
@@ -135,16 +133,12 @@ def get_target_variable(var):
         if (target_process_cls, target_var) in visited:  # pragma: no cover
             cycle = "->".join(
                 [
-                    f"{cls.__name__}.{var.name}"
-                    if cls is not None
-                    else var.name
+                    f"{cls.__name__}.{var.name}" if cls is not None else var.name
                     for cls, var in visited
                 ]
             )
 
-            raise RuntimeError(
-                f"Cycle detected in process dependencies: {cycle}"
-            )
+            raise RuntimeError(f"Cycle detected in process dependencies: {cycle}")
 
     return target_process_cls, target_var
 

--- a/xsimlab/utils.py
+++ b/xsimlab/utils.py
@@ -118,14 +118,14 @@ class AttrMapping:
             with suppress(KeyError):
                 return self._mapping[name]
         raise AttributeError(
-            "%r object has no attribute %r" % (type(self).__name__, name)
+            f"{type(self).__name__!r} object has no attribute {name!r}"
         )
 
     def __setattr__(self, name, value):
         if self._initialized and name in self._mapping:
             raise AttributeError(
-                "cannot override attribute %r of this %r object"
-                % (name, type(self).__name__)
+                f"cannot override attribute {name!r} of "
+                f"this {type(self).__name__!r} object"
             )
         object.__setattr__(self, name, value)
 

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -65,8 +65,8 @@ def _as_dim_tuple(dims):
             ", ".join(str(d) for d in group) for group in invalid_dims
         )
         raise ValueError(
-            "the following combinations of dimension labels "
-            "are ambiguous for a variable: {}".format(invalid_msg)
+            f"the following combinations of dimension labels "
+            f"are ambiguous for a variable: {invalid_msg}"
         )
 
     return tuple(dims)
@@ -285,8 +285,8 @@ def foreign(other_process_cls, var_name, intent="in"):
     if intent == "inout":
         raise ValueError("intent='inout' is not supported for " "foreign variables")
 
-    description = "Reference to variable {!r} " "defined in class {!r}".format(
-        var_name, other_process_cls.__name__
+    description = (
+        f"Reference to variable {var_name!r} defined in class {other_process_cls.__name__!r}"
     )
 
     metadata = {
@@ -327,7 +327,7 @@ def group(name):
     :func:`variable`
 
     """
-    description = "Iterable of all variables that " "belong to group {!r}".format(name)
+    description = f"Iterable of all variables that belong to group {name!r}"
 
     metadata = {
         "var_type": VarType.GROUP,

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -283,7 +283,7 @@ def foreign(other_process_cls, var_name, intent="in"):
 
     """
     if intent == "inout":
-        raise ValueError("intent='inout' is not supported for " "foreign variables")
+        raise ValueError("intent='inout' is not supported for foreign variables")
 
     description = (
         f"Reference to variable {var_name!r} defined "

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -65,7 +65,7 @@ def _as_dim_tuple(dims):
             ", ".join(str(d) for d in group) for group in invalid_dims
         )
         raise ValueError(
-            f"the following combinations of dimension labels "
+            "the following combinations of dimension labels "
             f"are ambiguous for a variable: {invalid_msg}"
         )
 
@@ -286,7 +286,8 @@ def foreign(other_process_cls, var_name, intent="in"):
         raise ValueError("intent='inout' is not supported for " "foreign variables")
 
     description = (
-        f"Reference to variable {var_name!r} defined in class {other_process_cls.__name__!r}"
+        f"Reference to variable {var_name!r} defined "
+        f"in class {other_process_cls.__name__!r}"
     )
 
     metadata = {

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -233,8 +233,8 @@ class SimlabAccessor:
         invalid_inputs = set(input_vars) - set(model.input_vars)
         if invalid_inputs:
             raise KeyError(
-                f"{', '.join([str(k) for k in invalid_inputs])} "
-                f"is/are not valid key(s) for input variables in model {model}"
+                ", ".join([str(k) for k in invalid_inputs]),
+                f" is/are not valid key(s) for input variables in model {model}",
             )
 
         for (p_name, var_name), data in input_vars.items():
@@ -280,8 +280,8 @@ class SimlabAccessor:
         invalid_outputs = set(output_vars) - set(model.all_vars)
         if invalid_outputs:
             raise KeyError(
-                f"{', '.join([str(k) for k in invalid_outputs])} "
-                f"is/are not valid key(s) for variables in model {model}"
+                ", ".join([str(k) for k in invalid_outputs]),
+                f" is/are not valid key(s) for variables in model {model}",
             )
 
         clock_vars = defaultdict(list)

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -233,7 +233,7 @@ class SimlabAccessor:
         invalid_inputs = set(input_vars) - set(model.input_vars)
         if invalid_inputs:
             raise KeyError(
-                f"{', '.join([str(k) for k in invalid_inputs])} " 
+                f"{', '.join([str(k) for k in invalid_inputs])} "
                 f"is/are not valid key(s) for input variables in model {model}"
             )
 

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -171,7 +171,7 @@ class SimlabAccessor:
 
         if xr_var.dims != (dim,):
             raise ValueError(
-                f"Invalid dimension(s) given for clock coordinate "
+                "Invalid dimension(s) given for clock coordinate "
                 f"{dim!r}: found {xr_var.dims!r}, "
                 f"expected {dim!r}"
             )
@@ -198,7 +198,7 @@ class SimlabAccessor:
             if dim not in self._ds.coords:
                 raise KeyError(
                     f"Master clock dimension name {dim} as no "
-                    f"defined coordinate in Dataset"
+                    "defined coordinate in Dataset"
                 )
 
             self._ds[dim].attrs[self._master_clock_key] = np.uint8(True)
@@ -225,7 +225,7 @@ class SimlabAccessor:
                 raise ValueError(
                     f"Clock coordinate {clock_dim} is not synchronized "
                     f"with master clock coordinate {self.master_clock_dim}. "
-                    f"The following coordinate labels are "
+                    "The following coordinate labels are "
                     f"absent in master clock: {diff_idx.values}"
                 )
 
@@ -406,7 +406,7 @@ class SimlabAccessor:
             ):
                 raise KeyError(
                     f"Master clock dimension name {master_clock_dim!r} not found "
-                    f"in `clocks` nor in Dataset"
+                    "in `clocks` nor in Dataset"
                 )
 
             for dim, data in clocks.items():

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -39,7 +39,7 @@ def _maybe_get_model_from_context(model):
             raise TypeError("No model found in context")
 
     if not isinstance(model, Model):
-        raise TypeError("%s is not an instance of xsimlab.Model" % model)
+        raise TypeError(f"{model} is not an instance of xsimlab.Model")
 
     return model
 
@@ -66,7 +66,7 @@ def as_variable_key(key):
                 key_tuple = (p_name, var_name)
 
     if key_tuple is None:
-        raise ValueError("{!r} is not a valid input variable key".format(key))
+        raise ValueError(f"{key!r} is not a valid input variable key")
 
     return key_tuple
 
@@ -115,8 +115,7 @@ def _flatten_outputs(output_vars):
 
         else:
             raise ValueError(
-                "Cannot interpret {!r} as valid output "
-                "variable key(s)".format(out_vars)
+                f"Cannot interpret {out_vars!r} as valid output variable key(s)"
             )
 
         flatten_vars[clock] = var_list
@@ -172,9 +171,9 @@ class SimlabAccessor:
 
         if xr_var.dims != (dim,):
             raise ValueError(
-                "Invalid dimension(s) given for clock coordinate "
-                "{dim!r}: found {invalid_dims!r}, "
-                "expected {dim!r}".format(dim=dim, invalid_dims=xr_var.dims)
+                f"Invalid dimension(s) given for clock coordinate "
+                f"{dim!r}: found {xr_var.dims!r}, "
+                f"expected {dim!r}"
             )
 
         xr_var.attrs[self._clock_key] = np.uint8(True)
@@ -198,8 +197,8 @@ class SimlabAccessor:
 
             if dim not in self._ds.coords:
                 raise KeyError(
-                    "Master clock dimension name {} as no "
-                    "defined coordinate in Dataset".format(dim)
+                    f"Master clock dimension name {dim} as no "
+                    f"defined coordinate in Dataset"
                 )
 
             self._ds[dim].attrs[self._master_clock_key] = np.uint8(True)
@@ -224,21 +223,18 @@ class SimlabAccessor:
 
             if diff_idx.size:
                 raise ValueError(
-                    "Clock coordinate {} is not synchronized "
-                    "with master clock coordinate {}. "
-                    "The following coordinate labels are "
-                    "absent in master clock: {}".format(
-                        clock_dim, self.master_clock_dim, diff_idx.values
-                    )
+                    f"Clock coordinate {clock_dim} is not synchronized "
+                    f"with master clock coordinate {self.master_clock_dim}. "
+                    f"The following coordinate labels are "
+                    f"absent in master clock: {diff_idx.values}"
                 )
 
     def _set_input_vars(self, model, input_vars):
         invalid_inputs = set(input_vars) - set(model.input_vars)
         if invalid_inputs:
             raise KeyError(
-                "{} is/are not valid key(s) for input variables in model {}".format(
-                    ", ".join([str(k) for k in invalid_inputs]), model
-                )
+                f"{', '.join([str(k) for k in invalid_inputs])} " 
+                f"is/are not valid key(s) for input variables in model {model}"
             )
 
         for (p_name, var_name), data in input_vars.items():
@@ -284,9 +280,8 @@ class SimlabAccessor:
         invalid_outputs = set(output_vars) - set(model.all_vars)
         if invalid_outputs:
             raise KeyError(
-                "{} is/are not valid key(s) for variables in model {}".format(
-                    ", ".join([str(k) for k in invalid_outputs]), model
-                )
+                f"{', '.join([str(k) for k in invalid_outputs])} "
+                f"is/are not valid key(s) for variables in model {model}"
             )
 
         clock_vars = defaultdict(list)
@@ -294,7 +289,7 @@ class SimlabAccessor:
         for (p_name, var_name), clock in output_vars.items():
             if clock is not None and clock not in self.clock_coords:
                 raise ValueError(
-                    "{!r} coordinate is not a valid clock coordinate.".format(clock)
+                    f"{clock!r} coordinate is not a valid clock coordinate."
                 )
 
             xr_var_name = p_name + "__" + var_name
@@ -403,15 +398,15 @@ class SimlabAccessor:
         if clocks is not None:
             if master_clock_dim is None:
                 raise ValueError(
-                    "Cannot determine which clock coordinate is " "the master clock"
+                    "Cannot determine which clock coordinate is the master clock"
                 )
             elif (
                 master_clock_dim not in clocks
                 and master_clock_dim not in self.clock_coords
             ):
                 raise KeyError(
-                    "Master clock dimension name {!r} not found "
-                    "in `clocks` nor in Dataset".format(master_clock_dim)
+                    f"Master clock dimension name {master_clock_dim!r} not found "
+                    f"in `clocks` nor in Dataset"
                 )
 
             for dim, data in clocks.items():

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -233,8 +233,8 @@ class SimlabAccessor:
         invalid_inputs = set(input_vars) - set(model.input_vars)
         if invalid_inputs:
             raise KeyError(
-                ", ".join([str(k) for k in invalid_inputs]),
-                f" is/are not valid key(s) for input variables in model {model}",
+                ", ".join([str(k) for k in invalid_inputs])
+                + f" is/are not valid key(s) for input variables in model {model}",
             )
 
         for (p_name, var_name), data in input_vars.items():
@@ -280,8 +280,8 @@ class SimlabAccessor:
         invalid_outputs = set(output_vars) - set(model.all_vars)
         if invalid_outputs:
             raise KeyError(
-                ", ".join([str(k) for k in invalid_outputs]),
-                f" is/are not valid key(s) for variables in model {model}",
+                ", ".join([str(k) for k in invalid_outputs])
+                + f" is/are not valid key(s) for variables in model {model}",
             )
 
         clock_vars = defaultdict(list)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #80 
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

A few cases where `str.format()` is used instead of its corresponding f-string were left in the code due to readability. The rest should be taken care of.
