### PR TITLE
Propagate original description to foreign variables

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,10 +47,10 @@ Enhancements
   to :func:`xarray.Dataset.xsimlab.run`.
 - More consistent dictionary format for output variables in the xarray
   extension (:issue:`85`).
-- :func:`~xsimlab.foreign` has been updated to get the original description
-  of a foreign variable
 - %-formatting and str.format() code has been converted into formatted string
   literals (f-strings) (:issue:`90`).
+- :func:`~xsimlab.foreign` has been updated to get the original description
+  of a foreign variable (:issue:`91`)
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,6 +47,7 @@ Enhancements
   to :func:`xarray.Dataset.xsimlab.run`.
 - More consistent dictionary format for output variables in the xarray
   extension (:issue:`85`).
+- :func:`~xsimlab.foreign` has been updated to return its original description
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,7 +47,8 @@ Enhancements
   to :func:`xarray.Dataset.xsimlab.run`.
 - More consistent dictionary format for output variables in the xarray
   extension (:issue:`85`).
-- :func:`~xsimlab.foreign` has been updated to return its original description
+- :func:`~xsimlab.foreign` has been updated to return the original description
+  of a foreign variable
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -47,7 +47,7 @@ Enhancements
   to :func:`xarray.Dataset.xsimlab.run`.
 - More consistent dictionary format for output variables in the xarray
   extension (:issue:`85`).
-- :func:`~xsimlab.foreign` has been updated to return the original description
+- :func:`~xsimlab.foreign` has been updated to get the original description
   of a foreign variable
 
 Bug fixes

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -23,7 +23,7 @@ class SomeProcess:
 class AnotherProcess:
     """Just used for foreign variables in ExampleProcess."""
 
-    another_var = xs.variable()
+    another_var = xs.variable(description = "original description")
     some_var = xs.foreign(SomeProcess, "some_var")
 
 

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -23,7 +23,7 @@ class SomeProcess:
 class AnotherProcess:
     """Just used for foreign variables in ExampleProcess."""
 
-    another_var = xs.variable(description = "original description")
+    another_var = xs.variable(description="original description")
     some_var = xs.foreign(SomeProcess, "some_var")
 
 

--- a/xsimlab/tests/test_variable.py
+++ b/xsimlab/tests/test_variable.py
@@ -1,6 +1,7 @@
 import pytest
+import attr
 
-from xsimlab.tests.fixture_process import ExampleProcess
+from xsimlab.tests.fixture_process import AnotherProcess, ExampleProcess
 from xsimlab.variable import _as_dim_tuple, _as_group_tuple, foreign
 
 
@@ -54,9 +55,8 @@ def test_as_group_tuple(groups, group, expected):
 def test_foreign():
     with pytest.raises(ValueError) as excinfo:
         foreign(ExampleProcess, "some_var", intent="inout")
-
     assert "intent='inout' is not supported" in str(excinfo.value)
-    assert (
-        foreign(ExampleProcess, "out_foreign_var").metadata["description"]
-        == "original description"
-    )
+
+    actual = attr.fields(ExampleProcess).out_foreign_var.metadata["description"]
+    expected = attr.fields(AnotherProcess).another_var.metadata["description"]
+    assert actual == expected

--- a/xsimlab/tests/test_variable.py
+++ b/xsimlab/tests/test_variable.py
@@ -56,4 +56,7 @@ def test_foreign():
         foreign(ExampleProcess, "some_var", intent="inout")
 
     assert "intent='inout' is not supported" in str(excinfo.value)
-    assert foreign(ExampleProcess, "out_foreign_var").metadata["description"] == "original description"
+    assert (
+        foreign(ExampleProcess, "out_foreign_var").metadata["description"]
+        == "original description"
+    )

--- a/xsimlab/tests/test_variable.py
+++ b/xsimlab/tests/test_variable.py
@@ -56,3 +56,4 @@ def test_foreign():
         foreign(ExampleProcess, "some_var", intent="inout")
 
     assert "intent='inout' is not supported" in str(excinfo.value)
+    assert foreign(ExampleProcess, "out_foreign_var").metadata["description"] == "original description"

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -288,7 +288,7 @@ def foreign(other_process_cls, var_name, intent="in"):
 
     for key, value in variables_dict(other_process_cls).items():
         if key == var_name:
-             description = value.metadata.get("description")
+            description = value.metadata.get("description")
 
     metadata = {
         "var_type": VarType.FOREIGN,

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -4,6 +4,7 @@ import warnings
 
 import attr
 from attr._make import _CountingAttr
+from .utils import variables_dict
 
 
 class VarType(Enum):
@@ -285,9 +286,9 @@ def foreign(other_process_cls, var_name, intent="in"):
     if intent == "inout":
         raise ValueError("intent='inout' is not supported for " "foreign variables")
 
-    description = "Reference to variable {!r} " "defined in class {!r}".format(
-        var_name, other_process_cls.__name__
-    )
+    for key, value in variables_dict(other_process_cls).items():
+        if key == var_name:
+             description = value.metadata.get("description")
 
     metadata = {
         "var_type": VarType.FOREIGN,

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -4,7 +4,6 @@ import warnings
 
 import attr
 from attr._make import _CountingAttr
-from .utils import variables_dict
 
 
 class VarType(Enum):
@@ -286,7 +285,7 @@ def foreign(other_process_cls, var_name, intent="in"):
     if intent == "inout":
         raise ValueError("intent='inout' is not supported for foreign variables")
 
-    description = variables_dict(other_process_cls)[var_name].metadata["description"]
+    description = attr.fields_dict(other_process_cls)[var_name].metadata["description"]
 
     metadata = {
         "var_type": VarType.FOREIGN,

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -286,9 +286,7 @@ def foreign(other_process_cls, var_name, intent="in"):
     if intent == "inout":
         raise ValueError("intent='inout' is not supported for " "foreign variables")
 
-    for key, value in variables_dict(other_process_cls).items():
-        if key == var_name:
-            description = value.metadata.get("description")
+    description = variables_dict(other_process_cls)[var_name].metadata["description"]
 
     metadata = {
         "var_type": VarType.FOREIGN,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

[PR#88](https://github.com/benbovy/xarray-simlab/pull/88) was closed and the code has been changed in order to work independently from the autodoc-feature ([PR#67](https://github.com/benbovy/xarray-simlab/pull/67)).

 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes

I use `variables_dict()` from `utils.py`.
Since attrs is already imported in `variables.py`, the following line would return the same result:
```python
description = attr.fields_dict(other_process_cls)[var_name].metadata["description"])
```

From my understanding, foreign variables always belong to xsimlab variables. Therefore, we technically could use `attr.fields_dict()` instead. What do you think, @benbovy ?
My first inclination was, to iterate over `variables_dict(other_process_cls).items()` but luckily, the construct makes it accessibly as is 👍 

There's already a test included in `test_variable.py`. Should we update this one to account for these changes or is it better to test at another place (e.g. as part of autodoc)?