### PR TITLE
WIP: Callback system and progress bar

### DIFF
--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -70,12 +70,22 @@ class BaseSimulationDriver:
 
     """
 
-    def __init__(self, model, store, output_store):
+    def __init__(self, model, store, output_store, start, pretask, posttask, finish, stage):
         self.model = model
         self.store = store
         self.output_store = output_store
+        self._start = start
+        self._pretask = pretask
+        self._posttask = posttask
+        self._finish = finish
+        self._stage = stage
 
         self._bind_store_to_model()
+
+    @property
+    def _callback(self):
+        fields = ["_start", "_pretask", "_posttask", "_finish", "_stage"]
+        return tuple(getattr(self, i, None) for i in fields)
 
     def _bind_store_to_model(self):
         """Bind the simulation active data store to each process in the


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #65 
 - [ ] Tests added
 - [ ] Passes `black . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

The idea behind this PR is to establish a callback systems that allows using callback mechanisms, e.g. for a progress bar, runtime diagnostics...
For now, this is a work in progress as it is not functioning at the moment. I would rather use this PR to stepwise implement this feature. However, I hope the code gives a good impression of what it is trying to accomplish.
The basic concept is implemented in `drivers.BaseSimulationDriver`. `self._start`, `self._prestep` and `self._stop` (`_finish` might be more fitting) should later be used to get information about the current run (e.g. in the class `ProgressBar` but generally any callback mechanism that will be implemented). I think my biggest issue here is so 'link' these instance variables to any simulation that is running. This becomes clear when looking at `drivers.ProgressBar`. Currently, they don't serve any real purpose and I'm not even sure they can get the needed information since all of that is set up in `drivers.XarraySimulationDriver`. I'm also not sure how detailed the individual stages are defined since any run follows the following concept:

* initialize all components
* iteration over run_step and finalize_step
* finalize

I don't intent to change the overall modelling logic so instead of having information about what stage is running, finished or waiting to run (as what I was trying to do with the `steps` dictionary in `_update_bar()`), we might also use step-data from `ds_gby_steps`(returned by `_get_runtime_datasets()` - though, these might not be helpful regarding `initialize` and `finalize`). To summarise, I think what I'm missing is a data type that I can use to retrieve information. I can imagine that it is already there and I'm simply not aware of.

Documentation is missing for now since I expect that this routine will change quite a lot in the future.

Lastly, some callables might be better suited to `xsimlab.drivers` but I'm afraid that would lead to circular imports.

This might take me some time, so I welcome any proposals and criticisms :)