### PR TITLE
Add zarr simulation output store

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -7,6 +7,8 @@ dependencies:
   - numpy=1.17.2
   - pandas=0.25.1
   - xarray=0.13.0
+  - netcdf4=1.5.3
+  - dask=2.11.0
   - ipython=7.8.0
   - matplotlib=3.0.2
   - graphviz

--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -15,3 +15,4 @@ dependencies:
   - nbconvert=5.6.0
   - sphinx=1.8.5
   - pandoc=2.7.3
+  - zarr=2.4.0

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -10,6 +10,7 @@ dependencies:
   - graphviz
   - python-graphviz
   - ipython
+  - zarr
   - pip:
     - coveralls
     - pytest-cov

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -7,6 +7,7 @@ dependencies:
   - pytest
   - numpy
   - xarray
+  - dask
   - graphviz
   - python-graphviz
   - ipython

--- a/ci/requirements/py37-attrs-dev.yml
+++ b/ci/requirements/py37-attrs-dev.yml
@@ -6,6 +6,7 @@ dependencies:
   - pytest
   - numpy
   - xarray
+  - dask
   - zarr
   - pip:
     - git+https://github.com/python-attrs/attrs.git

--- a/ci/requirements/py37-attrs-dev.yml
+++ b/ci/requirements/py37-attrs-dev.yml
@@ -6,6 +6,7 @@ dependencies:
   - pytest
   - numpy
   - xarray
+  - zarr
   - pip:
     - git+https://github.com/python-attrs/attrs.git
     - coveralls

--- a/ci/requirements/py37-xarray-dev.yml
+++ b/ci/requirements/py37-xarray-dev.yml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.7
   - pytest
   - numpy
+  - zarr
   - pip:
     - git+https://github.com/pydata/xarray.git
     - coveralls

--- a/ci/requirements/py37-xarray-dev.yml
+++ b/ci/requirements/py37-xarray-dev.yml
@@ -7,6 +7,7 @@ dependencies:
   - pytest
   - numpy
   - zarr
+  - dask
   - pip:
     - git+https://github.com/pydata/xarray.git
     - coveralls

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -10,6 +10,7 @@ dependencies:
   - graphviz
   - python-graphviz
   - ipython
+  - zarr
   - pip:
     - coveralls
     - pytest-cov

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -7,6 +7,7 @@ dependencies:
   - pytest
   - numpy
   - xarray
+  - dask
   - graphviz
   - python-graphviz
   - ipython

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -9,6 +9,7 @@ dependencies:
   - xarray
   - graphviz
   - python-graphviz
+  - zarr
   - pip:
     - coveralls
     - pytest-cov

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -7,6 +7,7 @@ dependencies:
   - pytest
   - numpy
   - xarray
+  - dask
   - graphviz
   - python-graphviz
   - zarr

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -213,6 +213,7 @@ intersphinx_mapping = {
     "attr": ("http://www.attrs.org/en/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "xarray": ("https://xarray.pydata.org/en/stable/", None),
+    "zarr": ("https://zarr.readthedocs.io/en/stable/", None),
 }
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,6 +35,7 @@ Documentation index
 * :doc:`create_model`
 * :doc:`inspect_model`
 * :doc:`run_model`
+* :doc:`io_storage`
 * :doc:`monitor`
 * :doc:`testing`
 
@@ -47,6 +48,7 @@ Documentation index
    create_model
    inspect_model
    run_model
+   io_storage
    monitor
    testing
 

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -10,6 +10,7 @@ Required dependencies
 - `attrs <http://www.attrs.org>`__ (18.2.0 or later)
 - `numpy <http://www.numpy.org/>`__
 - `xarray <http://xarray.pydata.org>`__ (0.10.0 or later)
+- `zarr <https://zarr.readthedocs.io>`__ (2.3.0 or later)
 
 Optional dependencies
 ---------------------

--- a/doc/io_storage.rst
+++ b/doc/io_storage.rst
@@ -21,8 +21,8 @@ Using xarray
 
 The :class:`xarray.Dataset` structure, used for both simulation inputs and
 outputs, already supports serialization and I/O to several file formats, among
-which netCDF_ is the recommended format. For more information, see the `reading
-and writing files`_ section of xarray's docs.
+which netCDF_ is the recommended format. For more information, see section
+`reading and writing files`_ in xarray's docs.
 
 .. _netCDF: https://www.unidata.ucar.edu/software/netcdf/
 .. _`reading and writing files`: http://xarray.pydata.org/en/stable/io.html
@@ -62,7 +62,7 @@ You can save the dataset here above, e.g., using :meth:`xarray.Dataset.to_netcdf
 
    ds.to_netcdf("model2_setup.nc")
 
-So that you can reload this setup later or elsewhere before running a
+You can then reload this setup later or elsewhere before starting a new
 simulation:
 
 .. ipython:: python
@@ -72,9 +72,9 @@ simulation:
    out_ds = in_ds.xsimlab.run(model=model2)
    out_ds
 
-The latter dataset ``out_ds`` contains both the inputs and outputs of this model
-run, that you can also write to a netCDF file or any other format supported by
-xarray, e.g.,
+The latter dataset ``out_ds`` contains both the inputs and the outputs of this
+model run. Likewise, You can write it to a netCDF file or any other format
+supported by xarray, e.g.,
 
 .. ipython:: python
 
@@ -84,11 +84,11 @@ Using zarr
 ----------
 
 When :meth:`xarray.Dataset.xsimlab.run` is called, xarray-simlab uses the zarr_
-library to efficiently store (i.e., with compression) both the inputs and the
-outputs. The output data is stored progressively as the simulation proceeds.
+library to efficiently store (i.e., with compression) both simulation input and
+output data. The output data is stored progressively as the simulation proceeds.
 
-By default all this data is saved into memory. When the amount of model I/O data
-is bigger, it is recommended to save the data on disk. For example, you can
+By default all this data is saved into memory. For large amounts of model I/O
+data, however, it is recommended to save the data on disk. For example, you can
 specify a directory where to store it:
 
 .. ipython:: python
@@ -116,19 +116,20 @@ to overwrite a directory that has been used for old model runs:
    distributed/cloud and database storage systems (see `storage alternatives`_
    in zarr's tutorial). Note, however, that a few alternatives won't work well
    with xarray-simlab. For example, :class:`zarr.ZipStore` doesn't support
-   feeding a dataset once it has been created.
+   feeding a zarr dataset once it has been created.
 
 Regardless of the chosen alternative, :meth:`xarray.Dataset.xsimlab.run` returns
-a ``xarray.Dataset`` containing the data (lazily) loaded from the zarr store:
+a ``xarray.Dataset`` object that contains the data (lazily) loaded from the zarr
+store:
 
 .. ipython:: python
 
    out_ds
 
-Zarr stores large multi-dimensional arrays as contiguous chunks. Xarray keeps track of
-those chunks, which enables efficient, parallel post-processing or visualization
-via the dask_ library (see the `parallel computing with Dask`_ section in
-xarray's docs).
+Zarr stores large multi-dimensional arrays as contiguous chunks. When opened as
+a ``xarray.Dataset``, xarray keeps track of those chunks, which enables efficient
+and parallel post-processing via the dask_ library (see section `parallel
+computing with Dask`_ in xarray's docs).
 
 .. _`storage alternatives`: https://zarr.readthedocs.io/en/stable/tutorial.html#storage-alternatives
 .. _`parallel computing with Dask`: http://xarray.pydata.org/en/stable/dask.html

--- a/doc/io_storage.rst
+++ b/doc/io_storage.rst
@@ -1,0 +1,144 @@
+.. _io_storage:
+
+Store Model Inputs and Outputs
+==============================
+
+Model inputs and/or outputs can be kept in memory or saved on disk using either
+`xarray`_'s or `zarr`_'s I/O capabilities.
+
+.. _xarray: http://xarray.pydata.org
+.. _zarr: https://zarr.readthedocs.io/en/stable
+
+.. ipython:: python
+   :suppress:
+
+    import sys
+    sys.path.append('scripts')
+    from advection_model import model2
+
+Using xarray
+------------
+
+The :class:`xarray.Dataset` structure, used for both simulation inputs and
+outputs, already supports serialization and I/O to several file formats, among
+which netCDF_ is the recommended format. For more information, see the `reading
+and writing files`_ section of xarray's docs.
+
+.. _netCDF: https://www.unidata.ucar.edu/software/netcdf/
+.. _`reading and writing files`: http://xarray.pydata.org/en/stable/io.html
+
+Before showing some examples, let's first create the same initial setup than the
+one used in section :doc:`run_model`:
+
+.. ipython:: python
+
+    model2
+
+.. ipython:: python
+
+    import xsimlab as xs
+    ds = xs.create_setup(
+        model=model2,
+        clocks={
+            'time': np.linspace(0., 1., 101),
+            'otime': [0, 0.5, 1]
+        },
+        master_clock='time',
+        input_vars={
+            'grid': {'length': 1.5, 'spacing': 0.01},
+            'init': {'loc': 0.3, 'scale': 0.1},
+            'advect__v': 1.
+        },
+        output_vars={
+            'grid__x': None,
+            'profile__u': 'otime'
+        }
+    )
+    ds
+
+You can save the dataset here above, e.g., using :meth:`xarray.Dataset.to_netcdf`
+
+.. ipython:: python
+
+   ds.to_netcdf("model2_setup.nc")
+
+So that you can reload this setup later or elsewhere before running a
+simulation:
+
+.. ipython:: python
+
+   import xarray as xr
+   in_ds = xr.load_dataset("model2_setup.nc")
+   out_ds = in_ds.xsimlab.run(model=model2)
+   out_ds
+
+The latter dataset ``out_ds`` contains both the inputs and outputs of this model
+run, that you can also write to a netCDF file or any other format supported by
+xarray, e.g.,
+
+.. ipython:: python
+
+   out_ds.to_netcdf("model2_run.nc")
+
+Using zarr
+----------
+
+When :meth:`xarray.Dataset.xsimlab.run` is called, xarray-simlab uses the zarr_
+library to efficiently store (i.e., with compression) both the inputs and the
+outputs. The output data is stored progressively as the simulation proceeds.
+
+By default all this data is saved into memory. When the amount of model I/O data
+is bigger, it is recommended to save the data on disk. For example, you can
+specify a directory where to store it:
+
+.. ipython:: python
+
+   out_ds = in_ds.xsimlab.run(model=model2, output_store="model2_run.zarr")
+
+You can also store the data in a temporary directory:
+
+.. ipython:: python
+
+   import zarr
+   out_ds = in_ds.xsimlab.run(model=model2, output_store=zarr.TempStore())
+
+Or you can directly use :func:`zarr.group` for more options, e.g., if you want
+to overwrite a directory that has been used for old model runs:
+
+.. ipython:: python
+
+   zg = zarr.group("model2_run.zarr", overwrite=True)
+   out_ds = in_ds.xsimlab.run(model=model2, output_store=zg)
+
+.. note::
+
+   The zarr library provides many storage alternatives, including support for
+   distributed/cloud and database storage systems (see `storage alternatives`_
+   in zarr's tutorial). Note, however, that a few alternatives won't work well
+   with xarray-simlab. For example, :class:`zarr.ZipStore` doesn't support
+   feeding a dataset once it has been created.
+
+Regardless of the chosen alternative, :meth:`xarray.Dataset.xsimlab.run` returns
+a ``xarray.Dataset`` containing the data (lazily) loaded from the zarr store:
+
+.. ipython:: python
+
+   out_ds
+
+Zarr stores large multi-dimensional arrays as contiguous chunks. Xarray keeps track of
+those chunks, which enables efficient, parallel post-processing or visualization
+via the dask_ library (see the `parallel computing with Dask`_ section in
+xarray's docs).
+
+.. _`storage alternatives`: https://zarr.readthedocs.io/en/stable/tutorial.html#storage-alternatives
+.. _`parallel computing with Dask`: http://xarray.pydata.org/en/stable/dask.html
+.. _dask: https://dask.org/
+
+.. ipython:: python
+   :suppress:
+
+   import os
+   import shutil
+   os.remove("model2_setup.nc")
+   os.remove("model2_run.nc")
+   shutil.rmtree("model2_run.zarr")

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,6 +68,7 @@ Enhancements
   :class:`~xsimlab.RuntimeHook` class.
 - Added some useful properties and methods to the ``xarray.Dataset.xsimlab``
   extension (:issue:`103`).
+- Save model inputs/outputs using zarr (:issue:`102`).
 
 Bug fixes
 ~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(),
     long_description=(open("README.rst").read() if exists("README.rst") else ""),
     python_requires=">=3.5",
-    install_requires=["attrs >= 18.1.0", "numpy", "xarray >= 0.10.0"],
+    install_requires=["attrs >= 18.1.0", "numpy", "xarray >= 0.10.0", "zarr >= 2.3.0"],
     tests_require=["pytest >= 3.3.0"],
     zip_safe=False,
 )

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -225,7 +225,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
             check_dims = CheckDimsOption(check_dims)
         self._check_dims_option = check_dims
 
-        self._transposed_vars = {}
+        self._transposed_dims = {}
 
         if validate is not None:
             validate = ValidateOption(validate)
@@ -282,7 +282,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
         transpose = self._check_dims_option is CheckDimsOption.TRANSPOSE
 
         if transpose and xr_dims_set in dims_set:
-            self._transposed_vars[(p_name, var_name)] = xr_var.dims
+            self._transposed_dims[(p_name, var_name)] = xr_var.dims
             xr_var = xr_var.transpose(*dims_set[xr_dims_set])
 
         if (strict or transpose) and xr_var.dims not in dims:
@@ -345,7 +345,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
                 data = data[0]
 
         dims = _get_dims_from_variable(data, var, clock)
-        original_dims = self._transposed_vars.get(key)
+        original_dims = self._transposed_dims.get(key)
 
         if clock is not None:
             dims = (clock,) + dims

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -3,10 +3,9 @@ from enum import Enum
 from typing import Any, Iterator, Mapping
 
 import attr
-import numpy as np
-import xarray as xr
 
 from .hook import flatten_hooks, group_hooks, RuntimeHook
+from .stores import ZarrOutputStore
 from .utils import variables_dict
 
 
@@ -75,10 +74,9 @@ class BaseSimulationDriver:
 
     """
 
-    def __init__(self, model, store, output_store):
+    def __init__(self, model, store):
         self.model = model
         self.store = store
-        self.output_store = output_store
 
         self._bind_store_to_model()
 
@@ -143,17 +141,6 @@ class BaseSimulationDriver:
         """
         self._set_in_store(input_vars, check_static=True)
 
-    def update_output_store(self, output_var_keys):
-        """Update the simulation output store (i.e., append new values to the
-        store) from snapshots of variables given in ``output_var_keys`` list.
-        """
-        for key in output_var_keys:
-            p_name, var_name = key
-            p_obj = self.model._processes[p_name]
-            value = getattr(p_obj, var_name)
-
-            self.output_store.append(key, value)
-
     def validate(self, p_names):
         """Run validators for all processes given in `p_names`."""
 
@@ -165,23 +152,6 @@ class BaseSimulationDriver:
         implemented in sub-classes).
         """
         raise NotImplementedError()
-
-
-def _get_dims_from_variable(array, var, clock):
-    """Given an array with numpy compatible interface and a
-    (xarray-simlab) variable, return dimension labels for the
-    array.
-
-    """
-    ndim = array.ndim
-    if clock is not None:
-        ndim -= 1  # ignore clock dimension
-
-    for dims in var.metadata["dims"]:
-        if len(dims) == ndim:
-            return dims
-
-    return tuple()
 
 
 class XarraySimulationDriver(BaseSimulationDriver):
@@ -202,7 +172,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
         dataset,
         model,
         store,
-        output_store,
+        zobject,
         check_dims=CheckDimsOption.STRICT,
         validate=ValidateOption.INPUTS,
         hooks=None,
@@ -210,7 +180,9 @@ class XarraySimulationDriver(BaseSimulationDriver):
         self.dataset = dataset
         self.model = model
 
-        super(XarraySimulationDriver, self).__init__(model, store, output_store)
+        super(XarraySimulationDriver, self).__init__(model, store)
+
+        self.output_store = ZarrOutputStore(dataset, model, zobject)
 
         self.master_clock_dim = dataset.xsimlab.master_clock_dim
         if self.master_clock_dim is None:
@@ -225,7 +197,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
             check_dims = CheckDimsOption(check_dims)
         self._check_dims_option = check_dims
 
-        self._transposed_dims = {}
+        self._original_dims = {}
 
         if validate is not None:
             validate = ValidateOption(validate)
@@ -251,26 +223,6 @@ class XarraySimulationDriver(BaseSimulationDriver):
         if missing_xr_vars:
             raise KeyError(f"Missing variables {missing_xr_vars} in Dataset")
 
-    def _get_output_save_steps(self):
-        """Returns a dictionary where keys are names of clock coordinates and
-        values are numpy boolean arrays that specify whether or not to
-        save outputs at every step of a simulation.
-        """
-        save_steps = {}
-
-        master_coord = self.dataset[self.master_clock_dim]
-
-        for clock, coord in self.dataset.xsimlab.clock_coords.items():
-            if clock == self.master_clock_dim:
-                save_steps[clock] = np.ones_like(coord.values, dtype=bool)
-            else:
-                save_steps[clock] = np.in1d(master_coord.values, coord.values)
-
-        save_steps[None] = np.zeros_like(master_coord.values, dtype=bool)
-        save_steps[None][-1] = True
-
-        return save_steps
-
     def _maybe_transpose(self, xr_var, p_name, var_name):
         var = variables_dict(self.model[p_name].__class__)[var_name]
 
@@ -282,7 +234,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
         transpose = self._check_dims_option is CheckDimsOption.TRANSPOSE
 
         if transpose and xr_dims_set in dims_set:
-            self._transposed_dims[(p_name, var_name)] = xr_var.dims
+            self._original_dims[xr_var.name] = xr_var.dims
             xr_var = xr_var.transpose(*dims_set[xr_dims_set])
 
         if (strict or transpose) and xr_var.dims not in dims:
@@ -315,85 +267,6 @@ class XarraySimulationDriver(BaseSimulationDriver):
             input_vars[(p_name, var_name)] = data
 
         return input_vars
-
-    def _maybe_save_output_vars(self, istep):
-        var_list = []
-
-        for key, clock in self.output_vars.items():
-            if self.output_save_steps[clock][istep]:
-                var_list.append(key)
-
-        self.update_output_store(var_list)
-
-    def _to_xr_variable(self, key, clock, index=False):
-        """Convert an output variable to a xarray.Variable object.
-
-        Maybe transpose the variable to match the dimension order
-        of the variable given in the input dataset (if any).
-
-        """
-        p_name, var_name = key
-        p_obj = self.model[p_name]
-        var = variables_dict(type(p_obj))[var_name]
-
-        if index:
-            # get index directly from simulation store
-            data = self.store[key]
-        else:
-            data = self.output_store[key]
-            if clock is None:
-                data = data[0]
-
-        dims = _get_dims_from_variable(data, var, clock)
-        original_dims = self._transposed_dims.get(key)
-
-        if clock is not None:
-            dims = (clock,) + dims
-
-            if original_dims is not None:
-                original_dims = (clock,) + original_dims
-
-        attrs = var.metadata["attrs"].copy()
-        if var.metadata["description"]:
-            attrs["description"] = var.metadata["description"]
-
-        xr_var = xr.Variable(dims, data, attrs=attrs)
-
-        if original_dims is not None:
-            # TODO: use ellipsis for clock dim in transpose
-            # added in xarray 0.14.1 (too recent)
-            xr_var = xr_var.transpose(*original_dims)
-
-        return xr_var
-
-    def _get_output_dataset(self):
-        """Return a new dataset as a copy of the input dataset updated with
-        output variables and index variables.
-        """
-        out_ds = self.dataset.copy()
-
-        # add/update output variables
-        xr_vars = {}
-
-        for key, clock in self.output_vars.items():
-            var_name = "__".join(key)
-            xr_vars[var_name] = self._to_xr_variable(key, clock, index=False)
-
-        out_ds.update(xr_vars)
-
-        # remove output_vars attributes in output dataset
-        out_ds.xsimlab._reset_output_vars(self.model, {})
-
-        # add/update index variables
-        xr_coords = {}
-
-        for key in self.model.index_vars():
-            _, var_name = key
-            xr_coords[var_name] = self._to_xr_variable(key, None, index=True)
-
-        out_ds.coords.update(xr_coords)
-
-        return out_ds
 
     def _get_runtime_datasets(self):
         mclock_dim = self.master_clock_dim
@@ -428,6 +301,27 @@ class XarraySimulationDriver(BaseSimulationDriver):
         if self._validate_option is not None:
             self.validate(p_names)
 
+    def _get_output_dataset(self):
+        self.output_store.consolidate()
+
+        out_ds = self.output_store.open_as_xr_dataset()
+
+        # replace index variables data with simulation data (could be Index objects)
+        for key in self.model.index_vars():
+            _, var_name = key
+            out_ds[var_name].data = self.store[key]
+
+        # transpose back
+        for xr_var_name, dims in self._original_dims.items():
+            xr_var = out_ds[xr_var_name]
+
+            reordered_dims = [d for d in xr_var.dims if d not in dims]
+            reordered_dims += dims
+
+            out_ds[xr_var_name] = xr_var.transpose(*reordered_dims)
+
+        return out_ds
+
     def run_model(self):
         """Run the model and return a new Dataset with all the simulation
         inputs and outputs.
@@ -438,6 +332,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
           'finalize_step' stages or at the end of the simulation.
 
         """
+        self.output_store.write_input_xr_dataset()
         ds_init, ds_gby_steps = self._get_runtime_datasets()
 
         validate_all = self._validate_option is ValidateOption.ALL
@@ -471,7 +366,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
                 "run_step", runtime_context, hooks=self._hooks, validate=validate_all,
             )
 
-            self._maybe_save_output_vars(step)
+            self.output_store.write_output_vars(self.store, step)
 
             self.model.execute(
                 "finalize_step",
@@ -480,7 +375,9 @@ class XarraySimulationDriver(BaseSimulationDriver):
                 validate=validate_all,
             )
 
-        self._maybe_save_output_vars(-1)
+        self.output_store.write_output_vars(self.store, -1)
+        self.output_store.write_index_vars(self.store)
+
         self.model.execute("finalize", runtime_context, hooks=self._hooks)
 
         return self._get_output_dataset()

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -367,7 +367,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
                 "run_step", runtime_context, hooks=self._hooks, validate=validate_all,
             )
 
-            self.output_store.write_output_vars(self.store, step)
+            self.output_store.write_output_vars(step)
 
             self.model.execute(
                 "finalize_step",
@@ -376,8 +376,8 @@ class XarraySimulationDriver(BaseSimulationDriver):
                 validate=validate_all,
             )
 
-        self.output_store.write_output_vars(self.store, -1)
-        self.output_store.write_index_vars(self.store)
+        self.output_store.write_output_vars(-1)
+        self.output_store.write_index_vars()
 
         self.model.execute("finalize", runtime_context, hooks=self._hooks)
 

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -489,6 +489,7 @@ class Model(AttrMapping, ContextMixin):
         """
         return self._get_vars_dict_from_cache("_all_vars")
 
+    @property
     def index_vars(self):
         """Returns all index variables in the model as a list of
         ``(process_name, var_name)`` tuples (or an empty list).

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -196,7 +196,7 @@ class ZarrOutputStore:
         else:
             chunks = "auto"
 
-        return xr.open_zarr(
+        ds = xr.open_zarr(
             self.zgroup.store,
             group=self.zgroup.path,
             chunks=chunks,
@@ -204,3 +204,9 @@ class ZarrOutputStore:
             # disable mask (not nice with zarr default fill_value=0)
             mask_and_scale=False,
         )
+
+        if self.in_memory:
+            # lazy loading may be confusing for the default, in-memory option
+            return ds.load()
+        else:
+            return ds

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -183,7 +183,7 @@ class ZarrOutputStore:
         # reset consolidated since metadata has just been updated
         self.consolidated = False
 
-    def write_output_vars(self, state: MutableMapping, istep: int):
+    def write_output_vars(self, istep: int):
         for clock, var_keys in self.output_vars.items():
             if not self.output_steps[clock][istep]:
                 continue
@@ -205,7 +205,7 @@ class ZarrOutputStore:
 
             self.clock_incs[clock] += 1
 
-    def write_index_vars(self, state: MutableMapping):
+    def write_index_vars(self):
         for var_key in self.model.index_vars:
             _, vname = var_key
             self._create_zarr_dataset(var_key, name=vname)

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -207,6 +207,11 @@ class ZarrOutputStore:
 
         if self.in_memory:
             # lazy loading may be confusing for the default, in-memory option
-            return ds.load()
+            ds.load()
         else:
-            return ds
+            # load scalar data vars (there might be many of them: model params)
+            for da in ds.data_vars.values():
+                if not da.dims:
+                    da.load()
+
+        return ds

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -107,11 +107,10 @@ class ZarrOutputStore:
 
         if clock is None:
             shape = array.shape
-            chunks = True  # auto chunks
         else:
             shape = (self.clock_sizes[clock],) + tuple(array.shape)
-            chunks = (1,) + tuple(array.shape)
 
+        chunks = True
         compressor = "default"
 
         # TODO: more performance assessment

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -1,22 +1,195 @@
 from collections import defaultdict
-from copy import copy
+from collections.abc import MutableMapping
+from typing import Any, Dict, Tuple, Union
 
 import numpy as np
+import xarray as xr
+import zarr
+
+from xsimlab import Model
+from xsimlab.process import variables_dict
 
 
-class InMemoryOutputStore:
-    """A simple, in-memory store for model outputs.
+_DIMENSION_KEY = "_ARRAY_DIMENSIONS"
 
-    It basically consists of a Python dictionary with lists as values,
-    which are converted to numpy arrays on store read-access.
+
+def _get_output_vars_by_clock(dataset: xr.Dataset) -> Dict[str, Tuple[str, str]]:
+    out_vars = defaultdict(list)
+
+    for k, clock in dataset.xsimlab.output_vars.items():
+        out_vars[clock].append(k)
+
+    return out_vars
+
+
+def _get_output_vars_str(dataset: xr.Dataset) -> Dict[Tuple[str, str], str]:
+    return {
+        (pname, vname): pname + "__" + vname
+        for (pname, vname) in dataset.xsimlab.output_vars
+    }
+
+
+def _get_output_steps_by_clock(dataset: xr.Dataset) -> Dict[str, np.ndarray]:
+    """Returns a dictionary where keys are names of clock coordinates and
+    values are numpy boolean arrays that specify whether or not to
+    save outputs at every step of a simulation.
 
     """
+    output_steps = {}
 
-    def __init__(self):
-        self._store = defaultdict(list)
+    mclock_dim = dataset.xsimlab.master_clock_dim
+    master_coord = dataset[mclock_dim]
 
-    def append(self, key, value):
-        self._store[key].append(copy(value))
+    for clock, coord in dataset.xsimlab.clock_coords.items():
+        if clock == mclock_dim:
+            output_steps[clock] = np.ones_like(coord.values, dtype=bool)
+        else:
+            output_steps[clock] = np.in1d(master_coord.values, coord.values)
 
-    def __getitem__(self, key):
-        return np.array(self._store[key])
+    output_steps[None] = np.zeros_like(master_coord.values, dtype=bool)
+    output_steps[None][-1] = True
+
+    return output_steps
+
+
+def _get_clock_sizes(dataset: xr.Dataset) -> Dict[str, int]:
+    return {clock: coord.size for clock, coord in dataset.xsimlab.clock_coords.items()}
+
+
+def _init_clock_incrementers(dataset: xr.Dataset) -> Dict[str, int]:
+    return {clock: 0 for clock in dataset.xsimlab.clock_coords}
+
+
+class ZarrOutputStore:
+    def __init__(
+        self,
+        dataset: xr.Dataset,
+        model: Model,
+        zobject: Union[zarr.Group, MutableMapping, str, None],
+    ):
+        self.dataset = dataset
+        self.model = model
+
+        self.in_memory = False
+        self.consolidated = False
+
+        if isinstance(zobject, zarr.Group):
+            self.zgroup = zobject
+        elif zobject is None:
+            self.zgroup = zarr.group(store=zarr.MemoryStore())
+            self.in_memory = True
+        else:
+            self.zgroup = zarr.group(store=zobject)
+
+        self.output_vars = _get_output_vars_by_clock(dataset)
+        self.output_vars_str = _get_output_vars_str(dataset)
+        self.output_steps = _get_output_steps_by_clock(dataset)
+
+        self.clock_sizes = _get_clock_sizes(dataset)
+        self.clock_incs = _init_clock_incrementers(dataset)
+
+    def write_input_xr_dataset(self):
+        # output variables already in input dataset will be replaced
+        ovars = self.dataset.xsimlab.output_vars.keys()
+        ds = self.dataset.drop(list(ovars), errors="ignore")
+
+        ds.xsimlab._reset_output_vars(self.model, {})
+        ds.to_zarr(self.zgroup.store, group=self.zgroup.path, mode="a")
+
+    def _create_zarr_dataset(
+        self, var_key: Tuple[str, str], name: str, array: Any, clock: str
+    ):
+        if clock is None:
+            shape = array.shape
+            chunks = True  # auto chunks
+        else:
+            shape = (self.clock_sizes[clock],) + tuple(array.shape)
+            chunks = (1,) + tuple(array.shape)
+
+        compressor = "default"
+
+        if self.in_memory:
+            # chunks = False    # assess performance impact first?
+            compressor = None
+
+        zdataset = self.zgroup.create_dataset(
+            name,
+            shape=shape,
+            chunks=chunks,
+            dtype=array.dtype,
+            compressor=compressor,
+            # TODO: smarter fill_value based on array dtype
+            #       (0 may be non-missing value)
+            fill_value=0,
+        )
+
+        # add dimension labels and variable attributes as metadata
+        p_name, var_name = var_key
+        p_obj = self.model[p_name]
+        var = variables_dict(type(p_obj))[var_name]
+
+        dim_labels = None
+
+        for dims in var.metadata["dims"]:
+            if len(dims) == array.ndim:
+                dim_labels = list(dims)
+
+        if dim_labels is None:
+            raise ValueError(
+                f"Output array of {array.ndim} dimension(s) "
+                f"for variable '{p_name}__{var_name}' doesn't match any of"
+                f"its accepted dimension(s): {var.metadata['dims']}"
+            )
+
+        if clock is not None:
+            dim_labels.insert(0, clock)
+
+        zdataset.attrs[_DIMENSION_KEY] = tuple(dim_labels)
+        zdataset.attrs["description"] = var.metadata["description"]
+        zdataset.attrs.update(var.metadata["attrs"])
+
+        # reset consolidated since metadata has just been updated
+        self.consolidated = False
+
+    def write_output_vars(self, state: MutableMapping, istep: int):
+        for clock, var_keys in self.output_vars.items():
+            if not self.output_steps[clock][istep]:
+                continue
+
+            clock_inc = self.clock_incs[clock]
+
+            if clock_inc == 0:
+                for vk in var_keys:
+                    name = self.output_vars_str[vk]
+                    self._create_zarr_dataset(vk, name, state[vk], clock)
+
+            for vk in var_keys:
+                vk_str = self.output_vars_str[vk]
+                self.zgroup[vk_str][clock_inc] = state[vk]
+
+            self.clock_incs[clock] += 1
+
+    def write_index_vars(self, state: MutableMapping):
+        for var_key in self.model.index_vars:
+            _, vname = var_key
+            self._create_zarr_dataset(var_key, vname, state[var_key], None)
+            self.zgroup[vname][:] = state[var_key]
+
+    def consolidate(self):
+        zarr.consolidate_metadata(self.zgroup.store)
+        self.consolidated = True
+
+    def open_as_xr_dataset(self) -> xr.Dataset:
+        if self.in_memory:
+            chunks = None
+        else:
+            chunks = "auto"
+
+        return xr.open_zarr(
+            self.zgroup.store,
+            group=self.zgroup.path,
+            chunks=chunks,
+            consolidated=self.consolidated,
+            # disable mask (not nice with zarr default fill_value=0)
+            mask_and_scale=False,
+        )

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -116,9 +116,10 @@ class ZarrOutputStore:
 
         compressor = "default"
 
-        if self.in_memory:
-            # chunks = False    # assess performance impact first?
-            compressor = None
+        # TODO: more performance assessment
+        # if self.in_memory:
+        #     chunks = False
+        #     compressor = None
 
         zdataset = self.zgroup.create_dataset(
             name,

--- a/xsimlab/tests/fixture_model.py
+++ b/xsimlab/tests/fixture_model.py
@@ -79,7 +79,7 @@ class Add:
 @xs.process
 class AddOnDemand:
     offset = xs.variable(dims=[(), "x"], description="offset added to profile u")
-    u_diff = xs.on_demand(groups="diff")
+    u_diff = xs.on_demand(dims=[(), "x"], groups="diff")
 
     @u_diff.compute
     def _compute_u_diff(self):

--- a/xsimlab/tests/test_drivers.py
+++ b/xsimlab/tests/test_drivers.py
@@ -5,26 +5,22 @@ from xarray.testing import assert_identical
 
 import xsimlab as xs
 from xsimlab.drivers import (
-    _get_dims_from_variable,
     BaseSimulationDriver,
     RuntimeContext,
     XarraySimulationDriver,
 )
-from xsimlab.stores import InMemoryOutputStore
 
 
 @pytest.fixture
 def base_driver(model):
     store = {}
-    out_store = InMemoryOutputStore()
-    return BaseSimulationDriver(model, store, out_store)
+    return BaseSimulationDriver(model, store)
 
 
 @pytest.fixture
 def xarray_driver(in_dataset, model):
     store = {}
-    out_store = InMemoryOutputStore()
-    return XarraySimulationDriver(in_dataset, model, store, out_store)
+    return XarraySimulationDriver(in_dataset, model, store, None)
 
 
 def test_runtime_context():
@@ -79,15 +75,6 @@ class TestBaseDriver:
         with pytest.raises(RuntimeError, match=r".* static variable .*"):
             base_driver.update_store(input_vars)
 
-    def test_update_output_store(self, base_driver):
-        base_driver.store[("init_profile", "n_points")] = 5
-        base_driver.model.init_profile.initialize()
-
-        base_driver.update_output_store([("profile", "u")])
-
-        expected = [np.array([1.0, 0.0, 0.0, 0.0, 0.0])]
-        assert_array_equal(base_driver.output_store[("profile", "u")], expected)
-
     def test_validate(self, base_driver):
         base_driver.store[("roll", "shift")] = 2.5
 
@@ -99,44 +86,19 @@ class TestBaseDriver:
             base_driver.run_model()
 
 
-@pytest.mark.parametrize(
-    "array,clock,expected",
-    [
-        (np.zeros((2, 2)), None, ("x", "y")),
-        (np.zeros((2, 2)), "clock", ("x",)),
-        (np.array(0), None, tuple()),
-    ],
-)
-def test_get_dims_from_variable(array, clock, expected):
-    var = xs.variable(dims=[(), ("x",), ("x", "y")])
-    assert _get_dims_from_variable(array, var, clock) == expected
-
-
 class TestXarraySimulationDriver:
     def test_constructor(self, in_dataset, model):
         store = {}
-        out_store = InMemoryOutputStore()
 
         invalid_ds = in_dataset.drop("clock")
         with pytest.raises(ValueError) as excinfo:
-            XarraySimulationDriver(invalid_ds, model, store, out_store)
+            XarraySimulationDriver(invalid_ds, model, store, None)
         assert "Missing master clock" in str(excinfo.value)
 
         invalid_ds = in_dataset.drop("init_profile__n_points")
         with pytest.raises(KeyError) as excinfo:
-            XarraySimulationDriver(invalid_ds, model, store, out_store)
+            XarraySimulationDriver(invalid_ds, model, store, None)
         assert "Missing variables" in str(excinfo.value)
-
-    def test_output_save_steps(self, xarray_driver):
-        expected = {
-            "clock": np.array([True, True, True, True, True]),
-            "out": np.array([True, False, True, False, True]),
-            None: np.array([False, False, False, False, True]),
-        }
-
-        assert xarray_driver.output_save_steps.keys() == expected.keys()
-        for k in expected:
-            assert_array_equal(xarray_driver.output_save_steps[k], expected[k])
 
     @pytest.mark.parametrize(
         "value,is_scalar", [(1, True), (("x", [1, 1, 1, 1, 1]), False)]
@@ -164,8 +126,12 @@ class TestXarraySimulationDriver:
     def test_run_model(self, in_dataset, out_dataset, xarray_driver):
         out_ds_actual = xarray_driver.run_model()
 
+        # skip attributes added by xr.open_zarr from check
+        for xr_var in out_ds_actual.variables.values():
+            xr_var.attrs.pop("_FillValue", None)
+
         assert out_ds_actual is not out_dataset
-        assert_identical(out_ds_actual, out_dataset)
+        assert_identical(out_ds_actual.load(), out_dataset)
 
     def test_runtime_context(self, in_dataset, model):
         @xs.process
@@ -176,7 +142,7 @@ class TestXarraySimulationDriver:
 
         m = model.update_processes({"p": P})
 
-        driver = XarraySimulationDriver(in_dataset, m, {}, InMemoryOutputStore())
+        driver = XarraySimulationDriver(in_dataset, m, {}, None)
 
         with pytest.raises(KeyError, match="'not_a_runtime_arg'"):
             driver.run_model()

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -47,7 +47,7 @@ class TestZarrOutputStore:
 
         out_store.write_output_vars(0)
 
-        ztest = zarr.open_group(out_store.zgroup.store, mode='r')
+        ztest = zarr.open_group(out_store.zgroup.store, mode="r")
 
         assert ztest.profile__u.shape == (in_dataset.clock.size, 3)
         assert_array_equal(ztest.profile__u[0], np.array([1.0, 2.0, 3.0]))
@@ -85,7 +85,7 @@ class TestZarrOutputStore:
         model.store[("init_profile", "x")] = np.array([1.0, 2.0, 3.0])
 
         out_store.write_index_vars()
-        ztest = zarr.open_group(out_store.zgroup.store, mode='r')
+        ztest = zarr.open_group(out_store.zgroup.store, mode="r")
 
         assert_array_equal(ztest.x, np.array([1.0, 2.0, 3.0]))
 

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -1,7 +1,15 @@
+from tempfile import mkdtemp
+
 import numpy as np
 from numpy.testing import assert_array_equal
+import pytest
+import xarray as xr
+import zarr
 
-from xsimlab.stores import _get_output_steps_by_clock
+from xsimlab.stores import (
+    _get_output_steps_by_clock,
+    ZarrOutputStore
+)
 
 
 def test_get_output_steps_by_clock(in_dataset):
@@ -16,3 +24,25 @@ def test_get_output_steps_by_clock(in_dataset):
     assert actual.keys() == expected.keys()
     for k in expected:
         assert_array_equal(actual[k], expected[k])
+
+
+class TestZarrOutputStore:
+
+    @pytest.mark.parametrize(
+        "zobject", [None, mkdtemp(), zarr.MemoryStore(), zarr.group()]
+    )
+    def test_constructor(self, in_dataset, model, zobject):
+        out_store = ZarrOutputStore(in_dataset, model, zobject)
+
+        assert out_store.zgroup.store is not None
+
+    def test_write_input_xr_dataset(self, in_dataset, model):
+        out_store = ZarrOutputStore(in_dataset, model, None)
+
+        out_store.write_input_xr_dataset()
+        ds = xr.open_zarr(out_store.zgroup.store, chunks=None)
+
+        xr.testing.assert_equal(ds, in_dataset)
+
+        # check output variables attrs removed before saving input dataset
+        assert not ds.xsimlab.output_vars

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -9,6 +9,14 @@ import zarr
 from xsimlab.stores import ZarrOutputStore
 
 
+def _bind_store(model):
+    store = {}
+    model.store = store
+
+    for p_obj in model.values():
+        p_obj.__xsimlab_store__ = store
+
+
 class TestZarrOutputStore:
     @pytest.mark.parametrize(
         "zobject", [None, mkdtemp(), zarr.MemoryStore(), zarr.group()]
@@ -28,3 +36,81 @@ class TestZarrOutputStore:
 
         # check output variables attrs removed before saving input dataset
         assert not ds.xsimlab.output_vars
+
+    def test_write_output_vars(self, in_dataset, model):
+        _bind_store(model)
+        out_store = ZarrOutputStore(in_dataset, model, None)
+
+        model.store[("profile", "u")] = np.array([1.0, 2.0, 3.0])
+        model.store[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
+        model.store[("add", "offset")] = 2.0
+
+        out_store.write_output_vars(0)
+
+        ztest = zarr.open_group(out_store.zgroup.store, mode='r')
+
+        assert ztest.profile__u.shape == (in_dataset.clock.size, 3)
+        assert_array_equal(ztest.profile__u[0], np.array([1.0, 2.0, 3.0]))
+
+        assert ztest.roll__u_diff.shape == (in_dataset.out.size, 3)
+        assert_array_equal(ztest.roll__u_diff[0], np.array([-1.0, 1.0, 0.0]))
+
+        assert ztest.add__u_diff.shape == (in_dataset.out.size,)
+        assert_array_equal(ztest.add__u_diff, np.array([2.0, np.nan, np.nan]))
+
+        # test save master clock but not out clock
+        out_store.write_output_vars(1)
+        assert_array_equal(ztest.profile__u[1], np.array([1.0, 2.0, 3.0]))
+        assert_array_equal(ztest.roll__u_diff[1], np.array([np.nan, np.nan, np.nan]))
+
+        # test save no-clock outputs
+        out_store.write_output_vars(-1)
+        assert_array_equal(ztest.profile__u_opp, np.array([-1.0, -2.0, -3.0]))
+
+    def test_write_output_vars_error(self, in_dataset, model):
+        _bind_store(model)
+        out_store = ZarrOutputStore(in_dataset, model, None)
+
+        model.store[("profile", "u")] = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        model.store[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
+        model.store[("add", "offset")] = 2.0
+
+        with pytest.raises(ValueError, match=r".*accepted dimension.*"):
+            out_store.write_output_vars(0)
+
+    def test_write_index_vars(self, in_dataset, model):
+        _bind_store(model)
+        out_store = ZarrOutputStore(in_dataset, model, None)
+
+        model.store[("init_profile", "x")] = np.array([1.0, 2.0, 3.0])
+
+        out_store.write_index_vars()
+        ztest = zarr.open_group(out_store.zgroup.store, mode='r')
+
+        assert_array_equal(ztest.x, np.array([1.0, 2.0, 3.0]))
+
+    def test_open_as_xr_dataset(self, in_dataset, model):
+        _bind_store(model)
+        out_store = ZarrOutputStore(in_dataset, model, None)
+
+        model.store[("profile", "u")] = np.array([1.0, 2.0, 3.0])
+        model.store[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
+        model.store[("add", "offset")] = 2.0
+
+        out_store.write_output_vars(0)
+
+        ds = out_store.open_as_xr_dataset()
+        assert ds.profile__u.chunks is None
+
+    def test_open_as_xr_dataset_chunks(self, in_dataset, model):
+        _bind_store(model)
+        out_store = ZarrOutputStore(in_dataset, model, mkdtemp())
+
+        model.store[("profile", "u")] = np.array([1.0, 2.0, 3.0])
+        model.store[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
+        model.store[("add", "offset")] = 2.0
+
+        out_store.write_output_vars(0)
+
+        ds = out_store.open_as_xr_dataset()
+        assert ds.profile__u.chunks is not None

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -6,28 +6,10 @@ import pytest
 import xarray as xr
 import zarr
 
-from xsimlab.stores import (
-    _get_output_steps_by_clock,
-    ZarrOutputStore
-)
-
-
-def test_get_output_steps_by_clock(in_dataset):
-    expected = {
-        "clock": np.array([True, True, True, True, True]),
-        "out": np.array([True, False, True, False, True]),
-        None: np.array([False, False, False, False, True]),
-    }
-
-    actual = _get_output_steps_by_clock(in_dataset)
-
-    assert actual.keys() == expected.keys()
-    for k in expected:
-        assert_array_equal(actual[k], expected[k])
+from xsimlab.stores import ZarrOutputStore
 
 
 class TestZarrOutputStore:
-
     @pytest.mark.parametrize(
         "zobject", [None, mkdtemp(), zarr.MemoryStore(), zarr.group()]
     )

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -1,18 +1,18 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from xsimlab.stores import InMemoryOutputStore
+from xsimlab.stores import _get_output_steps_by_clock
 
 
-def test_in_memory_output_store():
-    out_store = InMemoryOutputStore()
-    key = ("some_process", "some_var")
+def test_get_output_steps_by_clock(in_dataset):
+    expected = {
+        "clock": np.array([True, True, True, True, True]),
+        "out": np.array([True, False, True, False, True]),
+        None: np.array([False, False, False, False, True]),
+    }
 
-    arr = np.array([1, 2, 3])
-    out_store.append(key, arr)
-    arr[:] = [4, 5, 6]
-    out_store.append(key, arr)
+    actual = _get_output_steps_by_clock(in_dataset)
 
-    expected = np.array([[1, 2, 3], [4, 5, 6]])
-
-    assert_array_equal(out_store[key], expected)
+    assert actual.keys() == expected.keys()
+    for k in expected:
+        assert_array_equal(actual[k], expected[k])

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -567,6 +567,7 @@ class SimlabAccessor:
         model=None,
         check_dims="strict",
         validate="inputs",
+        output_store=None,
         hooks=None,
         safe_mode=True,
     ):
@@ -600,6 +601,13 @@ class SimlabAccessor:
             The latter may significantly impact performance, but it may be
             useful for debugging.
             If None is given, no validation is performed.
+        output_store : str or :class:`zarr.Group` object, optional
+            If a string (path) is given, output simulation data
+            will be saved in that specified directory in the file
+            system. If None is given (default), all output data
+            will be saved in memory. This parameter also directly
+            accepts a zarr group object or (most of) zarr store
+            objects for more storage options (see notes below).
         hooks : list, optional
             One or more runtime hooks, i.e., functions decorated with
             :func:`~xsimlab.runtime_hook` or instances of
@@ -610,10 +618,21 @@ class SimlabAccessor:
             simultaneously. Generally safe mode shouldn't be disabled, except
             in a few cases (e.g., debugging).
 
+        Notes
+        -----
+        xarray-simlab uses the zarr library (https://zarr.readthedocs.io) to
+        save model inputs and outputs during a simulation. zarr provides a
+        common interface to multiple storage solutions (e.g., in memory, on
+        disk, cloud-based storage, databases, etc.). Some stores may not work
+        well with xarray-simlab, though. For example
+        :class:`zarr.storage.ZipStore` is not supported because it is not
+        possible to write data to a dataset after it has been created.
+
         Returns
         -------
         output : Dataset
-            Another Dataset with both model inputs and outputs.
+            Another Dataset with both model inputs and outputs. The data is lazily
+            loaded from the zarr store used to save inputs and outputs.
 
         """
         model = _maybe_get_model_from_context(model)
@@ -627,7 +646,7 @@ class SimlabAccessor:
             self._ds,
             model,
             store,
-            None,
+            output_store,
             check_dims=check_dims,
             validate=validate,
             hooks=hooks,

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -11,7 +11,6 @@ from xarray import as_variable, Dataset, register_dataset_accessor
 
 from .drivers import XarraySimulationDriver
 from .model import Model
-from .stores import InMemoryOutputStore
 from .utils import variables_dict
 
 
@@ -623,13 +622,12 @@ class SimlabAccessor:
             model = model.clone()
 
         store = {}
-        output_store = InMemoryOutputStore()
 
         driver = XarraySimulationDriver(
             self._ds,
             model,
             store,
-            output_store,
+            None,
             check_dims=check_dims,
             validate=validate,
             hooks=hooks,


### PR DESCRIPTION
This basically allows efficient storage of model outputs (compression, chunked data) in memory or on disk or on a distributed file system or could storage systems... and get back these simulation data as a lazily loaded xarray.Dataset (optionally dask arrays). The xarray/dask/zarr combo is amazing! :-)

 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
