### PR TITLE
Foreign variables: get metadata from reference variable

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,7 +13,9 @@ Breaking changes
 - The keys of the dictionary returned by
   :attr:`xarray.Dataset.xsimlab.output_vars` now correspond to variable names,
   and the values are clock dimension labels or ``None`` (previously the
-  dictionary was formatted the other way around) (:issue:`85`).
+  dictionary was formatted the other way around).
+  :attr:`xarray.Dataset.xsimlab.output_vars_by_clock` has been added for
+  convenience (:issue:`85`, :issue:`103`).
 
 Depreciations
 ~~~~~~~~~~~~~
@@ -49,8 +51,8 @@ Enhancements
   extension (:issue:`85`).
 - %-formatting and str.format() code has been converted into formatted string
   literals (f-strings) (:issue:`90`).
-- :func:`~xsimlab.foreign` has been updated to get the original description
-  of a foreign variable (:issue:`91`)
+- :func:`~xsimlab.foreign` has been updated so that it sets its description and
+  its metadata from the variable it refers to (:issue:`91`, :issue:`107`).
 - The ``autodoc`` parameter of the :func:`xsimlab.process` decorator now allows
   to automatically add an attributes section to the docstring of the class to
   which the decorator is applied, using the metadata of each variable declared

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -23,7 +23,7 @@ class SomeProcess:
 class AnotherProcess:
     """Just used for foreign variables in ExampleProcess."""
 
-    another_var = xs.variable(description="original description")
+    another_var = xs.variable(description="original description", attrs={"unit": "m"})
     some_var = xs.foreign(SomeProcess, "some_var")
 
 

--- a/xsimlab/tests/test_variable.py
+++ b/xsimlab/tests/test_variable.py
@@ -62,6 +62,8 @@ def test_foreign():
         foreign(ExampleProcess, "some_var", intent="inout")
     assert "intent='inout' is not supported" in str(excinfo.value)
 
-    actual = attr.fields(ExampleProcess).out_foreign_var.metadata["description"]
-    expected = attr.fields(AnotherProcess).another_var.metadata["description"]
-    assert actual == expected
+    var = attr.fields(ExampleProcess).out_foreign_var
+    ref_var = attr.fields(AnotherProcess).another_var
+
+    for k in ("description", "attrs"):
+        assert var.metadata[k] == ref_var.metadata[k]

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -340,7 +340,9 @@ def foreign(other_process_cls, var_name, intent="in"):
     if intent == "inout":
         raise ValueError("intent='inout' is not supported for foreign variables")
 
-    description = attr.fields_dict(other_process_cls)[var_name].metadata["description"]
+    ref_var = attr.fields_dict(other_process_cls)[var_name]
+    description = ref_var.metadata["description"]
+    attrs = ref_var.metadata.get("attrs", {})
 
     metadata = {
         "var_type": VarType.FOREIGN,
@@ -348,6 +350,7 @@ def foreign(other_process_cls, var_name, intent="in"):
         "var_name": var_name,
         "intent": VarIntent(intent),
         "description": description,
+        "attrs": attrs
     }
 
     if VarIntent(intent) == VarIntent.OUT:

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -350,7 +350,7 @@ def foreign(other_process_cls, var_name, intent="in"):
         "var_name": var_name,
         "intent": VarIntent(intent),
         "description": description,
-        "attrs": attrs
+        "attrs": attrs,
     }
 
     if VarIntent(intent) == VarIntent.OUT:

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -341,16 +341,14 @@ def foreign(other_process_cls, var_name, intent="in"):
         raise ValueError("intent='inout' is not supported for foreign variables")
 
     ref_var = attr.fields_dict(other_process_cls)[var_name]
-    description = ref_var.metadata["description"]
-    attrs = ref_var.metadata.get("attrs", {})
 
     metadata = {
         "var_type": VarType.FOREIGN,
         "other_process_cls": other_process_cls,
         "var_name": var_name,
         "intent": VarIntent(intent),
-        "description": description,
-        "attrs": attrs,
+        "description": ref_var.metadata["description"],
+        "attrs": ref_var.metadata.get("attrs", {}),
     }
 
     if VarIntent(intent) == VarIntent.OUT:


### PR DESCRIPTION
Follow-up on #91

 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
