### PR TITLE
Concatenate output snapshots along arbitrary dimension 

### DIFF
--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -86,6 +86,7 @@ def in_var_details():
     - type : variable
     - intent : in
     - dims : (('x',), ('x', 'y'))
+    - concat_dim : None
     - groups : ()
     - static : False
     - attrs : {}

--- a/xsimlab/tests/test_formatting.py
+++ b/xsimlab/tests/test_formatting.py
@@ -77,6 +77,7 @@ def test_add_attribute_section():
         - type : variable
         - intent : in
         - dims : (('x',),)
+        - concat_dim : None
         - groups : ()
         - static : False
         - attrs : {}
@@ -87,6 +88,7 @@ def test_add_attribute_section():
         - type : variable
         - intent : in
         - dims : ((),)
+        - concat_dim : None
         - groups : ()
         - static : False
         - attrs : {}

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -188,8 +188,10 @@ def variable(
     dims_set = {d for dms in dims_t for d in dms}
 
     if concat_dim is not None and concat_dim not in dims_set:
-        raise ValueError(f"Concat dimension {concat_dim} not found in "
-                         f"the dimension labels set for this variable: {dims}")
+        raise ValueError(
+            f"Concat dimension {concat_dim} not found in "
+            f"the dimension labels set for this variable: {dims}"
+        )
 
     metadata = {
         "var_type": VarType.VARIABLE,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This is useful for variables that have a dynamic size (number of array elements) for one of their dimensions (for example, a model that simulates an ensemble made of a variable number of particles).

 - [ ] Tests added
 - [ ] Passes `black . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API


TODO: 

- [ ] also add concat_dim to `on_demand` variable
- [ ] get both `dims` and `concat_dim` from reference variable in `foreign`


