### PR TITLE
Auto-resize zarr datasets in output store

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -70,7 +70,7 @@ Enhancements
   :class:`~xsimlab.RuntimeHook` class.
 - Added some useful properties and methods to the ``xarray.Dataset.xsimlab``
   extension (:issue:`103`).
-- Save model inputs/outputs using zarr (:issue:`102`).
+- Save model inputs/outputs using zarr (:issue:`102`, :issue:`111`).
 - Added :class:`~xsimlab.monitoring.ProgressBar` to track simulation progress
   (:issue:`104`, :issue:`110`).
 

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -163,8 +163,8 @@ class ZarrOutputStore:
         self.consolidated = False
 
     def _maybe_resize_zarr_dataset(self, var_key: Tuple[str, str]):
-        # Increases then length of one or more dimensions of the zarr array,
-        # if this is needed (never shrinks dimensions).
+        # Maybe increases the length of one or more dimensions of
+        # the zarr array (only increases, never shrinks dimensions).
 
         zkey = self.var_info[var_key]["name"]
         zshape = self.var_info[var_key]["shape"]

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -104,14 +104,14 @@ class TestZarrOutputStore:
         _bind_store(model)
         out_store = ZarrOutputStore(in_ds, model, None)
 
-        for step in range(3):
-            model.store[("p", "arr")] = np.ones(step + 1)
+        for step, size in zip([0, 1, 2], [1, 3, 2]):
+            model.store[("p", "arr")] = np.ones(size)
             out_store.write_output_vars(step)
 
         ztest = zarr.open_group(out_store.zgroup.store, mode="r")
 
         expected = np.array(
-            [[1.0, np.nan, np.nan], [1.0, 1.0, np.nan], [1.0, 1.0, 1.0]]
+            [[1.0, np.nan, np.nan], [1.0, 1.0, 1.0], [1.0, 1.0, np.nan]]
         )
         assert_array_equal(ztest.p__arr, expected)
 


### PR DESCRIPTION
Implements option 2 in #109.

 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
