### PR TITLE
Rename store -> state and output_store -> store

### DIFF
--- a/doc/framework.rst
+++ b/doc/framework.rst
@@ -194,23 +194,18 @@ elsewhere.
 Get / set variable values inside a process
 ------------------------------------------
 
-Once you have declared a variable as a class attribute in a process, you
-can further get and/or set its value like it was defined as a property
-of that class. For example, if you declare a variable ``foo`` you can
-just use ``self.foo`` to get/set its value inside one method of that
-class.
+Once you have declared a variable as a class attribute in a process, you can
+further get and/or set its value like a regular instance attribute. For example,
+if you declare a variable ``foo`` you can just use ``self.foo`` to get/set its
+value inside one method of that class.
 
-This is exactly what does the :func:`~xsimlab.process` decorator: it
-takes all variables declared as class attributes and turns them into
-properties, which may be read-only depending on the ``intent`` set for
-the variables.
-
-Basically, the getter (setter) methods of these properties read
-(write) values from (into) a simple key-value store (except for
-on-demand variables). Currently the store is fully in-memory but it
-could be easily replaced by an on-disk or a distributed store. The
-xarray-simlab's modeling framework can thus be viewed as a thin
-object-oriented layer built on top of an abstract key-value store.
+Additionally, the :func:`~xsimlab.process` decorator takes all variables
+declared as class attributes and turns them into properties, which may be
+read-only depending on the ``intent`` set for the variables. For all variables
+except on-demand variables, the getter/setter methods of those properties
+read/write values via a simple dictionary that is common to a simulation. Note
+that those properties are created only for the case where a ``process``
+decorated class is used within a ``Model`` object.
 
 Process dependencies and ordering
 ---------------------------------

--- a/doc/io_storage.rst
+++ b/doc/io_storage.rst
@@ -3,8 +3,8 @@
 Store Model Inputs and Outputs
 ==============================
 
-Model inputs and/or outputs can be kept in memory or saved on disk using either
-`xarray`_'s or `zarr`_'s I/O capabilities.
+Simulation inputs and/or outputs can be kept in memory or saved on disk using
+either `xarray`_'s or `zarr`_'s I/O capabilities.
 
 .. _xarray: http://xarray.pydata.org
 .. _zarr: https://zarr.readthedocs.io/en/stable
@@ -85,7 +85,8 @@ Using zarr
 
 When :meth:`xarray.Dataset.xsimlab.run` is called, xarray-simlab uses the zarr_
 library to efficiently store (i.e., with compression) both simulation input and
-output data. The output data is stored progressively as the simulation proceeds.
+output data. Input data is stored before the simulation starts and output data
+is stored progressively as the simulation proceeds.
 
 By default all this data is saved into memory. For large amounts of model I/O
 data, however, it is recommended to save the data on disk. For example, you can

--- a/doc/io_storage.rst
+++ b/doc/io_storage.rst
@@ -94,14 +94,14 @@ specify a directory where to store it:
 
 .. ipython:: python
 
-   out_ds = in_ds.xsimlab.run(model=model2, output_store="model2_run.zarr")
+   out_ds = in_ds.xsimlab.run(model=model2, store="model2_run.zarr")
 
 You can also store the data in a temporary directory:
 
 .. ipython:: python
 
    import zarr
-   out_ds = in_ds.xsimlab.run(model=model2, output_store=zarr.TempStore())
+   out_ds = in_ds.xsimlab.run(model=model2, store=zarr.TempStore())
 
 Or you can directly use :func:`zarr.group` for more options, e.g., if you want
 to overwrite a directory that has been used for old model runs:
@@ -109,7 +109,7 @@ to overwrite a directory that has been used for old model runs:
 .. ipython:: python
 
    zg = zarr.group("model2_run.zarr", overwrite=True)
-   out_ds = in_ds.xsimlab.run(model=model2, output_store=zg)
+   out_ds = in_ds.xsimlab.run(model=model2, store=zg)
 
 .. note::
 

--- a/xsimlab/dot.py
+++ b/xsimlab/dot.py
@@ -53,7 +53,7 @@ def _hash_variable(var):
 
 def _get_target_keys(p_obj, var_name):
     return maybe_to_list(
-        p_obj.__xsimlab_store_keys__.get(var_name, [])
+        p_obj.__xsimlab_state_keys__.get(var_name, [])
     ) + maybe_to_list(p_obj.__xsimlab_od_keys__.get(var_name, []))
 
 

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -89,7 +89,7 @@ class BaseSimulationDriver:
         self.model.state = self.state
 
         for p_obj in self.model.values():
-            p_obj.__xsimlab_store__ = self.state
+            p_obj.__xsimlab_state__ = self.state
 
     def _set_state(self, input_vars, check_static=True):
         for key in self.model.input_vars:

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -86,7 +86,7 @@ class BaseSimulationDriver:
         """Bind the simulation active data store to each process in the
         model.
         """
-        self.model.store = self.state
+        self.model.state = self.state
 
         for p_obj in self.model.values():
             p_obj.__xsimlab_store__ = self.state

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -5,7 +5,7 @@ from typing import Any, Iterator, Mapping
 import attr
 
 from .hook import flatten_hooks, group_hooks, RuntimeHook
-from .stores import ZarrOutputStore
+from .stores import ZarrSimulationStore
 from .utils import variables_dict
 
 
@@ -204,7 +204,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
         hooks = set(hooks) | RuntimeHook.active
         self._hooks = group_hooks(flatten_hooks(hooks))
 
-        self.store = ZarrOutputStore(dataset, model, store)
+        self.store = ZarrSimulationStore(dataset, model, store)
 
     def _check_missing_model_inputs(self):
         """Check if all model inputs have their corresponding variables

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -103,7 +103,7 @@ class BaseSimulationDriver:
 
             if check_static and var.metadata.get("static", False):
                 raise RuntimeError(
-                    "Cannot set value in store for "
+                    "Cannot set value in simulation active store for "
                     f"static variable {var_name!r} defined "
                     f"in process {p_name!r}"
                 )

--- a/xsimlab/formatting.py
+++ b/xsimlab/formatting.py
@@ -53,7 +53,7 @@ def _summarize_var(var, process, col_width):
         var_info = f"{link_symbol} group {var.metadata['group']!r}"
 
     elif var_type == VarType.FOREIGN:
-        key = process.__xsimlab_store_keys__.get(var_name)
+        key = process.__xsimlab_state_keys__.get(var_name)
         if key is None:
             key = process.__xsimlab_od_keys__.get(var_name)
         if key is None:

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -37,7 +37,7 @@ class _ModelBuilder:
     - Attach the model instance to each process and assign their given
       name in model.
     - Define for each variable of the model its corresponding key
-      (in store or on-demand)
+      (in state or on-demand)
     - Find variables that are model inputs
     - Find process dependencies and sort processes (DAG)
     - Find the processes that implement the method relative to each
@@ -82,7 +82,7 @@ class _ModelBuilder:
             p_obj.__xsimlab_name__ = p_name
 
     def _get_var_key(self, p_name, var):
-        """Get store and/or on-demand keys for variable `var` declared in
+        """Get state and/or on-demand keys for variable `var` declared in
         process `p_name`.
 
         Returned key(s) are either None (if no key), a tuple or a list
@@ -93,13 +93,13 @@ class _ModelBuilder:
         variable declared in that process.
 
         """
-        store_key = None
+        state_key = None
         od_key = None
 
         var_type = var.metadata["var_type"]
 
         if var_type in (VarType.VARIABLE, VarType.INDEX):
-            store_key = (p_name, var.name)
+            state_key = (p_name, var.name)
 
         elif var_type == VarType.ON_DEMAND:
             od_key = (p_name, var.name)
@@ -128,53 +128,53 @@ class _ModelBuilder:
                     )
                 )
 
-            store_key, od_key = self._get_var_key(target_p_name, target_var)
+            state_key, od_key = self._get_var_key(target_p_name, target_var)
 
         elif var_type == VarType.GROUP:
             var_group = var.metadata["group"]
-            store_key, od_key = self._get_group_var_keys(var_group)
+            state_key, od_key = self._get_group_var_keys(var_group)
 
-        return store_key, od_key
+        return state_key, od_key
 
     def _get_group_var_keys(self, group):
-        """Get from cache or find model-wise store and on-demand keys
+        """Get from cache or find model-wise state and on-demand keys
         for all variables related to a group (except group variables).
 
         """
         if group in self._group_keys:
             return self._group_keys[group]
 
-        store_keys = []
+        state_keys = []
         od_keys = []
 
         for p_name, p_obj in self._processes_obj.items():
             for var in filter_variables(p_obj, group=group).values():
-                store_key, od_key = self._get_var_key(p_name, var)
+                state_key, od_key = self._get_var_key(p_name, var)
 
-                if store_key is not None:
-                    store_keys.append(store_key)
+                if state_key is not None:
+                    state_keys.append(state_key)
                 if od_key is not None:
                     od_keys.append(od_key)
 
-        self._group_keys[group] = store_keys, od_keys
+        self._group_keys[group] = state_keys, od_keys
 
-        return store_keys, od_keys
+        return state_keys, od_keys
 
     def set_process_keys(self):
-        """Find store and/or on-demand keys for all variables in a model and
+        """Find state and/or on-demand keys for all variables in a model and
         store them in their respective process, i.e., the following
         attributes:
 
-        __xsimlab_store_keys__  (store keys)
+        __xsimlab_store_keys__  (state keys)
         __xsimlab_od_keys__     (on-demand keys)
 
         """
         for p_name, p_obj in self._processes_obj.items():
             for var in filter_variables(p_obj).values():
-                store_key, od_key = self._get_var_key(p_name, var)
+                state_key, od_key = self._get_var_key(p_name, var)
 
-                if store_key is not None:
-                    p_obj.__xsimlab_store_keys__[var.name] = store_key
+                if state_key is not None:
+                    p_obj.__xsimlab_store_keys__[var.name] = state_key
                 if od_key is not None:
                     p_obj.__xsimlab_od_keys__[var.name] = od_key
 
@@ -233,7 +233,7 @@ class _ModelBuilder:
         Model input variables meet the following conditions:
 
         - model-wise (i.e., in all processes), there is no variable with
-          intent='out' targeting those variables (in store keys).
+          intent='out' targeting those variables (in state keys).
         - although group variables always have intent='in', they are not
           model inputs.
 
@@ -299,7 +299,7 @@ class _ModelBuilder:
         """
         self._dep_processes = {k: set() for k in self._processes_obj}
 
-        d_keys = {}  # all store/on-demand keys for each process
+        d_keys = {}  # all state/on-demand keys for each process
 
         for p_name, p_obj in self._processes_obj.items():
             d_keys[p_name] = _flatten_keys(
@@ -455,7 +455,7 @@ class Model(AttrMapping, ContextMixin):
         self._processes = builder.get_sorted_processes()
 
         # overwritten by simulation drivers
-        self.store = {}
+        self.state = {}
 
         super(Model, self).__init__(self._processes)
         self._initialized = True
@@ -574,7 +574,7 @@ class Model(AttrMapping, ContextMixin):
             return
 
         for h in event_hooks:
-            h(self, Frozen(runtime_context), Frozen(self.store))
+            h(self, Frozen(runtime_context), Frozen(self.state))
 
     def execute(self, stage, runtime_context, hooks=None, validate=False):
         """Run one stage of a simulation.

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -165,7 +165,7 @@ class _ModelBuilder:
         store them in their respective process, i.e., the following
         attributes:
 
-        __xsimlab_store_keys__  (state keys)
+        __xsimlab_state_keys__  (state keys)
         __xsimlab_od_keys__     (on-demand keys)
 
         """
@@ -174,7 +174,7 @@ class _ModelBuilder:
                 state_key, od_key = self._get_var_key(p_name, var)
 
                 if state_key is not None:
-                    p_obj.__xsimlab_store_keys__[var.name] = state_key
+                    p_obj.__xsimlab_state_keys__[var.name] = state_key
                 if od_key is not None:
                     p_obj.__xsimlab_od_keys__[var.name] = od_key
 
@@ -194,7 +194,7 @@ class _ModelBuilder:
 
         for p_name, p_obj in self._processes_obj.items():
             for var in filter_variables(p_obj, func=filter_out).values():
-                target_key = p_obj.__xsimlab_store_keys__.get(var.name)
+                target_key = p_obj.__xsimlab_state_keys__.get(var.name)
                 targets[target_key].append((p_name, var.name))
 
         conflicts = {k: v for k, v in targets.items() if len(v) > 1}
@@ -253,11 +253,11 @@ class _ModelBuilder:
 
         for p_name, p_obj in self._processes_obj.items():
             in_keys += [
-                p_obj.__xsimlab_store_keys__.get(var.name)
+                p_obj.__xsimlab_state_keys__.get(var.name)
                 for var in filter_variables(p_obj, func=filter_in).values()
             ]
             out_keys += [
-                p_obj.__xsimlab_store_keys__.get(var.name)
+                p_obj.__xsimlab_state_keys__.get(var.name)
                 for var in filter_variables(p_obj, func=filter_out).values()
             ]
 
@@ -282,7 +282,7 @@ class _ModelBuilder:
             )
 
             for var in out_foreign_vars.values():
-                pn, _ = p_obj.__xsimlab_store_keys__[var.name]
+                pn, _ = p_obj.__xsimlab_state_keys__[var.name]
                 processes_to_validate[p_name].add(pn)
 
         return {k: list(v) for k, v in processes_to_validate.items()}
@@ -304,7 +304,7 @@ class _ModelBuilder:
         for p_name, p_obj in self._processes_obj.items():
             d_keys[p_name] = _flatten_keys(
                 [
-                    p_obj.__xsimlab_store_keys__.values(),
+                    p_obj.__xsimlab_state_keys__.values(),
                     p_obj.__xsimlab_od_keys__.values(),
                 ]
             )
@@ -314,7 +314,7 @@ class _ModelBuilder:
                 if var.metadata["var_type"] == VarType.ON_DEMAND:
                     key = p_obj.__xsimlab_od_keys__[var.name]
                 else:
-                    key = p_obj.__xsimlab_store_keys__[var.name]
+                    key = p_obj.__xsimlab_state_keys__[var.name]
 
                 for pn in self._processes_obj:
                     if pn != p_name and key in d_keys[pn]:

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -164,7 +164,7 @@ def _make_property_variable(var):
     var_converter = var.converter or _dummy_converter
 
     def get_from_store(self):
-        key = self.__xsimlab_store_keys__[var_name]
+        key = self.__xsimlab_state_keys__[var_name]
         return self.__xsimlab_store__[key]
 
     def get_on_demand(self):
@@ -173,7 +173,7 @@ def _make_property_variable(var):
         return getattr(p_obj, v_name)
 
     def put_in_store(self, value):
-        key = self.__xsimlab_store_keys__[var_name]
+        key = self.__xsimlab_state_keys__[var_name]
         self.__xsimlab_store__[key] = var_converter(value)
 
     target_process_cls, target_var = get_target_variable(var)
@@ -242,7 +242,7 @@ def _make_property_group(var):
 
     def getter_store_or_on_demand(self):
         model = self.__xsimlab_model__
-        store_keys = self.__xsimlab_store_keys__.get(var_name, [])
+        store_keys = self.__xsimlab_state_keys__.get(var_name, [])
         od_keys = self.__xsimlab_od_keys__.get(var_name, [])
 
         for key in store_keys:
@@ -395,7 +395,7 @@ def _process_cls_init(obj):
         Name given for this process in the model.
     __xsimlab_store__ : dict or object
         Simulation data store.
-    __xsimlab_store_keys__ : dict
+    __xsimlab_state_keys__ : dict
         Dictionary that maps variable names to their corresponding key
         (or list of keys for group variables) in the store.
         Such keys consist of pairs like `('foo', 'bar')` where
@@ -410,7 +410,7 @@ def _process_cls_init(obj):
     obj.__xsimlab_model__ = None
     obj.__xsimlab_name__ = None
     obj.__xsimlab_store__ = None
-    obj.__xsimlab_store_keys__ = {}
+    obj.__xsimlab_state_keys__ = {}
     obj.__xsimlab_od_keys__ = {}
 
 

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -240,12 +240,12 @@ def _make_property_group(var):
 
     var_name = var.name
 
-    def getter_store_or_on_demand(self):
+    def getter_state_or_on_demand(self):
         model = self.__xsimlab_model__
-        store_keys = self.__xsimlab_state_keys__.get(var_name, [])
+        state_keys = self.__xsimlab_state_keys__.get(var_name, [])
         od_keys = self.__xsimlab_od_keys__.get(var_name, [])
 
-        for key in store_keys:
+        for key in state_keys:
             yield self.__xsimlab_state__[key]
 
         for key in od_keys:
@@ -253,7 +253,7 @@ def _make_property_group(var):
             p_obj = model._processes[p_name]
             yield getattr(p_obj, v_name)
 
-    return property(fget=getter_store_or_on_demand, doc=var_details(var))
+    return property(fget=getter_state_or_on_demand, doc=var_details(var))
 
 
 class _RuntimeMethodExecutor:
@@ -394,17 +394,17 @@ def _process_cls_init(obj):
     __xsimlab_name__ : str
         Name given for this process in the model.
     __xsimlab_state__ : dict or object
-        Simulation data store.
+        Simulation active data store.
     __xsimlab_state_keys__ : dict
         Dictionary that maps variable names to their corresponding key
-        (or list of keys for group variables) in the store.
+        (or list of keys for group variables) in the active store.
         Such keys consist of pairs like `('foo', 'bar')` where
         'foo' is the name of any process in the same model and 'bar' is
         the name of a variable declared in that process.
     __xsimlab_od_keys__ : dict
         Dictionary that maps variable names to the location of their target
         on-demand variable (or a list of locations for group variables).
-        Locations are tuples like store keys.
+        Locations are tuples like state keys.
 
     """
     obj.__xsimlab_model__ = None

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -153,8 +153,8 @@ def _make_property_variable(var):
     """Create a property for a variable or a foreign variable (after
     some sanity checks).
 
-    The property get/set functions either read/write values from/to
-    the simulation data store or get (and trigger computation of) the
+    The property get/set functions either read/write values from/to the active
+    simulation data store (i.e. state) or get (and trigger computation of) the
     value of an on-demand variable.
 
     The property is read-only if `var` is declared as input.
@@ -163,18 +163,18 @@ def _make_property_variable(var):
     var_name = var.name
     var_converter = var.converter or _dummy_converter
 
-    def get_from_store(self):
+    def get_from_state(self):
         key = self.__xsimlab_state_keys__[var_name]
-        return self.__xsimlab_store__[key]
+        return self.__xsimlab_state__[key]
 
     def get_on_demand(self):
         p_name, v_name = self.__xsimlab_od_keys__[var_name]
         p_obj = self.__xsimlab_model__._processes[p_name]
         return getattr(p_obj, v_name)
 
-    def put_in_store(self, value):
+    def put_in_state(self, value):
         key = self.__xsimlab_state_keys__[var_name]
-        self.__xsimlab_store__[key] = var_converter(value)
+        self.__xsimlab_state__[key] = var_converter(value)
 
     target_process_cls, target_var = get_target_variable(var)
 
@@ -211,10 +211,10 @@ def _make_property_variable(var):
         return property(fget=get_on_demand, doc=var_doc)
 
     elif var_intent == VarIntent.IN:
-        return property(fget=get_from_store, doc=var_doc)
+        return property(fget=get_from_state, doc=var_doc)
 
     else:
-        return property(fget=get_from_store, fset=put_in_store, doc=var_doc)
+        return property(fget=get_from_state, fset=put_in_state, doc=var_doc)
 
 
 def _make_property_on_demand(var):
@@ -246,7 +246,7 @@ def _make_property_group(var):
         od_keys = self.__xsimlab_od_keys__.get(var_name, [])
 
         for key in store_keys:
-            yield self.__xsimlab_store__[key]
+            yield self.__xsimlab_state__[key]
 
         for key in od_keys:
             p_name, v_name = key
@@ -393,7 +393,7 @@ def _process_cls_init(obj):
         :class:`Model` instance to which the process instance is attached.
     __xsimlab_name__ : str
         Name given for this process in the model.
-    __xsimlab_store__ : dict or object
+    __xsimlab_state__ : dict or object
         Simulation data store.
     __xsimlab_state_keys__ : dict
         Dictionary that maps variable names to their corresponding key
@@ -409,7 +409,7 @@ def _process_cls_init(obj):
     """
     obj.__xsimlab_model__ = None
     obj.__xsimlab_name__ = None
-    obj.__xsimlab_store__ = None
+    obj.__xsimlab_state__ = None
     obj.__xsimlab_state_keys__ = {}
     obj.__xsimlab_od_keys__ = {}
 

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -54,7 +54,7 @@ def default_fill_value_from_dtype(dtype):
         return 0
 
 
-class ZarrOutputStore:
+class ZarrSimulationStore:
     def __init__(
         self,
         dataset: xr.Dataset,

--- a/xsimlab/tests/conftest.py
+++ b/xsimlab/tests/conftest.py
@@ -4,7 +4,7 @@ from xsimlab.tests.fixture_process import (
     example_process_obj,
     example_process_repr,
     in_var_details,
-    processes_with_store,
+    processes_with_state,
     example_process_in_model_repr,
 )
 from xsimlab.tests.fixture_model import (

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -93,12 +93,12 @@ def in_var_details():
     )
 
 
-def _init_process(p_cls, p_name, model, store, store_keys=None, od_keys=None):
+def _init_process(p_cls, p_name, model, store, state_keys=None, od_keys=None):
     p_obj = get_process_obj(p_cls)
     p_obj.__xsimlab_name__ = p_name
     p_obj.__xsimlab_model__ = model
     p_obj.__xsimlab_store__ = store
-    p_obj.__xsimlab_store_keys__ = store_keys or {}
+    p_obj.__xsimlab_state_keys__ = state_keys or {}
     p_obj.__xsimlab_od_keys__ = od_keys or {}
     return p_obj
 
@@ -117,14 +117,14 @@ def processes_with_store():
         "some_process",
         model,
         store,
-        store_keys={"some_var": ("some_process", "some_var")},
+        state_keys={"some_var": ("some_process", "some_var")},
     )
     another_process = _init_process(
         AnotherProcess,
         "another_process",
         model,
         store,
-        store_keys={
+        state_keys={
             "another_var": ("another_process", "another_var"),
             "some_var": ("some_process", "some_var"),
         },
@@ -134,7 +134,7 @@ def processes_with_store():
         "example_process",
         model,
         store,
-        store_keys={
+        state_keys={
             "in_var": ("example_process", "in_var"),
             "out_var": ("example_process", "out_var"),
             "inout_var": ("example_process", "inout_var"),

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -93,11 +93,11 @@ def in_var_details():
     )
 
 
-def _init_process(p_cls, p_name, model, store, state_keys=None, od_keys=None):
+def _init_process(p_cls, p_name, model, state, state_keys=None, od_keys=None):
     p_obj = get_process_obj(p_cls)
     p_obj.__xsimlab_name__ = p_name
     p_obj.__xsimlab_model__ = model
-    p_obj.__xsimlab_store__ = store
+    p_obj.__xsimlab_state__ = state
     p_obj.__xsimlab_state_keys__ = state_keys or {}
     p_obj.__xsimlab_od_keys__ = od_keys or {}
     return p_obj

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -104,26 +104,26 @@ def _init_process(p_cls, p_name, model, state, state_keys=None, od_keys=None):
 
 
 @pytest.fixture
-def processes_with_store():
+def processes_with_state():
     class FakeModel:
         def __init__(self):
             self._processes = {}
 
     model = FakeModel()
-    store = {}
+    state = {}
 
     some_process = _init_process(
         SomeProcess,
         "some_process",
         model,
-        store,
+        state,
         state_keys={"some_var": ("some_process", "some_var")},
     )
     another_process = _init_process(
         AnotherProcess,
         "another_process",
         model,
-        store,
+        state,
         state_keys={
             "another_var": ("another_process", "another_var"),
             "some_var": ("some_process", "some_var"),
@@ -133,7 +133,7 @@ def processes_with_store():
         ExampleProcess,
         "example_process",
         model,
-        store,
+        state,
         state_keys={
             "in_var": ("example_process", "in_var"),
             "out_var": ("example_process", "out_var"),

--- a/xsimlab/tests/test_drivers.py
+++ b/xsimlab/tests/test_drivers.py
@@ -13,14 +13,14 @@ from xsimlab.drivers import (
 
 @pytest.fixture
 def base_driver(model):
-    store = {}
-    return BaseSimulationDriver(model, store)
+    state = {}
+    return BaseSimulationDriver(model, state)
 
 
 @pytest.fixture
 def xarray_driver(in_dataset, model):
-    store = {}
-    return XarraySimulationDriver(in_dataset, model, store, None)
+    state = {}
+    return XarraySimulationDriver(in_dataset, model, state, None)
 
 
 def test_runtime_context():
@@ -88,16 +88,16 @@ class TestBaseDriver:
 
 class TestXarraySimulationDriver:
     def test_constructor(self, in_dataset, model):
-        store = {}
+        state = {}
 
         invalid_ds = in_dataset.drop("clock")
         with pytest.raises(ValueError) as excinfo:
-            XarraySimulationDriver(invalid_ds, model, store, None)
+            XarraySimulationDriver(invalid_ds, model, state, None)
         assert "Missing master clock" in str(excinfo.value)
 
         invalid_ds = in_dataset.drop("init_profile__n_points")
         with pytest.raises(KeyError) as excinfo:
-            XarraySimulationDriver(invalid_ds, model, store, None)
+            XarraySimulationDriver(invalid_ds, model, state, None)
         assert "Missing variables" in str(excinfo.value)
 
     @pytest.mark.parametrize(

--- a/xsimlab/tests/test_drivers.py
+++ b/xsimlab/tests/test_drivers.py
@@ -36,47 +36,47 @@ def test_runtime_context():
 
 
 class TestBaseDriver:
-    def test_bind_store(self, base_driver):
-        base_driver.store[("init_profile", "n_points")] = 10
+    def test_bind_state(self, base_driver):
+        base_driver.state[("init_profile", "n_points")] = 10
         assert base_driver.model.init_profile.n_points == 10
 
-    def test_set_store_ignore(self, base_driver):
+    def test_set_state_ignore(self, base_driver):
         input_vars = {("not-a-model", "input"): 0}
-        base_driver.initialize_store(input_vars)
+        base_driver.initialize_state(input_vars)
 
-        assert ("not-a-model", "input") not in base_driver.store
+        assert ("not-a-model", "input") not in base_driver.state
 
-    def test_set_store_copy(self, base_driver):
+    def test_set_state_copy(self, base_driver):
         n = np.array([1, 2, 3, 4])
         input_vars = {("add", "offset"): n}
-        base_driver.initialize_store(input_vars)
+        base_driver.initialize_state(input_vars)
 
-        actual = base_driver.store[("add", "offset")]
+        actual = base_driver.state[("add", "offset")]
         assert_array_equal(actual, n)
         assert actual is not n
 
-    def test_set_store_converter(self, base_driver):
+    def test_set_state_converter(self, base_driver):
         input_vars = {("init_profile", "n_points"): 10.2}
-        base_driver.initialize_store(input_vars)
+        base_driver.initialize_state(input_vars)
 
-        actual = base_driver.store[("init_profile", "n_points")]
+        actual = base_driver.state[("init_profile", "n_points")]
         assert actual == 10
         assert type(actual) is int
 
-    def test_initialize_store(self, base_driver):
+    def test_initialize_state(self, base_driver):
         input_vars = {("init_profile", "n_points"): 10}
-        base_driver.initialize_store(input_vars)
+        base_driver.initialize_state(input_vars)
 
-        assert base_driver.store[("init_profile", "n_points")] == 10
+        assert base_driver.state[("init_profile", "n_points")] == 10
 
-    def test_update_store(self, base_driver):
+    def test_update_state(self, base_driver):
         input_vars = {("init_profile", "n_points"): 10}
 
         with pytest.raises(RuntimeError, match=r".* static variable .*"):
-            base_driver.update_store(input_vars)
+            base_driver.update_state(input_vars)
 
     def test_validate(self, base_driver):
-        base_driver.store[("roll", "shift")] = 2.5
+        base_driver.state[("roll", "shift")] = 2.5
 
         with pytest.raises(TypeError, match=r".*'int'.*"):
             base_driver.validate(["roll"])

--- a/xsimlab/tests/test_formatting.py
+++ b/xsimlab/tests/test_formatting.py
@@ -99,13 +99,13 @@ def test_add_attribute_section():
 
 def test_process_repr(
     example_process_obj,
-    processes_with_store,
+    processes_with_state,
     example_process_repr,
     example_process_in_model_repr,
 ):
     assert repr_process(example_process_obj) == example_process_repr
 
-    _, _, process_in_model = processes_with_store
+    _, _, process_in_model = processes_with_state
     assert repr_process(process_in_model) == example_process_in_model_repr
 
     @xs.process

--- a/xsimlab/tests/test_model.py
+++ b/xsimlab/tests/test_model.py
@@ -43,7 +43,7 @@ class TestModelBuilder:
         self, model, p_name, expected_store_keys, expected_od_keys
     ):
         p_obj = model._processes[p_name]
-        actual_store_keys = p_obj.__xsimlab_store_keys__
+        actual_store_keys = p_obj.__xsimlab_state_keys__
         actual_od_keys = p_obj.__xsimlab_od_keys__
 
         # key order is not ensured for group variables
@@ -69,8 +69,8 @@ class TestModelBuilder:
 
         m = xs.Model({"a": A, "b": B})
 
-        assert m.b.__xsimlab_store_keys__["g1"] == [("a", "v")]
-        assert m.b.__xsimlab_store_keys__["g2"] == [("a", "v")]
+        assert m.b.__xsimlab_state_keys__["g1"] == [("a", "v")]
+        assert m.b.__xsimlab_state_keys__["g2"] == [("a", "v")]
 
     def test_get_all_variables(self, model):
         assert all([len(t) == 2 for t in model.all_vars])

--- a/xsimlab/tests/test_model.py
+++ b/xsimlab/tests/test_model.py
@@ -11,7 +11,7 @@ class TestModelBuilder:
         assert model._processes["profile"].__xsimlab_name__ == "profile"
 
     @pytest.mark.parametrize(
-        "p_name,expected_store_keys,expected_od_keys",
+        "p_name,expected_state_keys,expected_od_keys",
         [
             (
                 "init_profile",
@@ -40,21 +40,21 @@ class TestModelBuilder:
         ],
     )
     def test_set_process_keys(
-        self, model, p_name, expected_store_keys, expected_od_keys
+        self, model, p_name, expected_state_keys, expected_od_keys
     ):
         p_obj = model._processes[p_name]
-        actual_store_keys = p_obj.__xsimlab_state_keys__
+        actual_state_keys = p_obj.__xsimlab_state_keys__
         actual_od_keys = p_obj.__xsimlab_od_keys__
 
         # key order is not ensured for group variables
-        if isinstance(expected_store_keys, list):
-            actual_store_keys = set(actual_store_keys)
-            expected_store_keys = set(expected_store_keys)
+        if isinstance(expected_state_keys, list):
+            actual_state_keys = set(actual_state_keys)
+            expected_state_keys = set(expected_state_keys)
         if isinstance(expected_od_keys, list):
             actual_od_keys = set(actual_od_keys)
             expected_od_keys = set(expected_od_keys)
 
-        assert actual_store_keys == expected_store_keys
+        assert actual_state_keys == expected_state_keys
         assert actual_od_keys == expected_od_keys
 
     def test_multiple_groups(self):

--- a/xsimlab/tests/test_process.py
+++ b/xsimlab/tests/test_process.py
@@ -177,8 +177,8 @@ def test_process_properties_docstrings(in_var_details):
     assert to_lines(_ExampleProcess.in_var.__doc__) == to_lines(in_var_details)
 
 
-def test_process_properties_values(processes_with_store):
-    some_process, another_process, example_process = processes_with_store
+def test_process_properties_values(processes_with_state):
+    some_process, another_process, example_process = processes_with_state
 
     assert example_process.od_var == 0
     assert example_process.in_foreign_od_var == 1
@@ -197,8 +197,8 @@ def test_process_properties_values(processes_with_store):
     assert set(example_process.group_var) == {1, 4}
 
 
-def test_process_properties_converter(processes_with_store):
-    _, _, example_process = processes_with_store
+def test_process_properties_converter(processes_with_state):
+    _, _, example_process = processes_with_state
 
     example_process.inout_var = 1.1
     assert example_process.inout_var == 1

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -7,7 +7,7 @@ import xarray as xr
 import zarr
 
 import xsimlab as xs
-from xsimlab.stores import ZarrOutputStore
+from xsimlab.stores import ZarrSimulationStore
 
 
 def _bind_state(model):
@@ -18,17 +18,17 @@ def _bind_state(model):
         p_obj.__xsimlab_state__ = state
 
 
-class TestZarrOutputStore:
+class TestZarrSimulationStore:
     @pytest.mark.parametrize(
         "zobject", [None, mkdtemp(), zarr.MemoryStore(), zarr.group()]
     )
     def test_constructor(self, in_dataset, model, zobject):
-        out_store = ZarrOutputStore(in_dataset, model, zobject)
+        out_store = ZarrSimulationStore(in_dataset, model, zobject)
 
         assert out_store.zgroup.store is not None
 
     def test_write_input_xr_dataset(self, in_dataset, model):
-        out_store = ZarrOutputStore(in_dataset, model, None)
+        out_store = ZarrSimulationStore(in_dataset, model, None)
 
         out_store.write_input_xr_dataset()
         ds = xr.open_zarr(out_store.zgroup.store, chunks=None)
@@ -40,7 +40,7 @@ class TestZarrOutputStore:
 
     def test_write_output_vars(self, in_dataset, model):
         _bind_state(model)
-        out_store = ZarrOutputStore(in_dataset, model, None)
+        out_store = ZarrSimulationStore(in_dataset, model, None)
 
         model.state[("profile", "u")] = np.array([1.0, 2.0, 3.0])
         model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
@@ -70,7 +70,7 @@ class TestZarrOutputStore:
 
     def test_write_output_vars_error(self, in_dataset, model):
         _bind_state(model)
-        out_store = ZarrOutputStore(in_dataset, model, None)
+        out_store = ZarrSimulationStore(in_dataset, model, None)
 
         model.state[("profile", "u")] = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
@@ -81,7 +81,7 @@ class TestZarrOutputStore:
 
     def test_write_index_vars(self, in_dataset, model):
         _bind_state(model)
-        out_store = ZarrOutputStore(in_dataset, model, None)
+        out_store = ZarrSimulationStore(in_dataset, model, None)
 
         model.state[("init_profile", "x")] = np.array([1.0, 2.0, 3.0])
 
@@ -102,7 +102,7 @@ class TestZarrOutputStore:
         )
 
         _bind_state(model)
-        out_store = ZarrOutputStore(in_ds, model, None)
+        out_store = ZarrSimulationStore(in_ds, model, None)
 
         for step, size in zip([0, 1, 2], [1, 3, 2]):
             model.state[("p", "arr")] = np.ones(size)
@@ -117,7 +117,7 @@ class TestZarrOutputStore:
 
     def test_open_as_xr_dataset(self, in_dataset, model):
         _bind_state(model)
-        out_store = ZarrOutputStore(in_dataset, model, None)
+        out_store = ZarrSimulationStore(in_dataset, model, None)
 
         model.state[("profile", "u")] = np.array([1.0, 2.0, 3.0])
         model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
@@ -130,7 +130,7 @@ class TestZarrOutputStore:
 
     def test_open_as_xr_dataset_chunks(self, in_dataset, model):
         _bind_state(model)
-        out_store = ZarrOutputStore(in_dataset, model, mkdtemp())
+        out_store = ZarrSimulationStore(in_dataset, model, mkdtemp())
 
         model.state[("profile", "u")] = np.array([1.0, 2.0, 3.0])
         model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -12,7 +12,7 @@ from xsimlab.stores import ZarrOutputStore
 
 def _bind_state(model):
     state = {}
-    model.store = state
+    model.state = state
 
     for p_obj in model.values():
         p_obj.__xsimlab_state__ = state
@@ -42,9 +42,9 @@ class TestZarrOutputStore:
         _bind_state(model)
         out_store = ZarrOutputStore(in_dataset, model, None)
 
-        model.store[("profile", "u")] = np.array([1.0, 2.0, 3.0])
-        model.store[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
-        model.store[("add", "offset")] = 2.0
+        model.state[("profile", "u")] = np.array([1.0, 2.0, 3.0])
+        model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
+        model.state[("add", "offset")] = 2.0
 
         out_store.write_output_vars(0)
 
@@ -72,9 +72,9 @@ class TestZarrOutputStore:
         _bind_state(model)
         out_store = ZarrOutputStore(in_dataset, model, None)
 
-        model.store[("profile", "u")] = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        model.store[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
-        model.store[("add", "offset")] = 2.0
+        model.state[("profile", "u")] = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
+        model.state[("add", "offset")] = 2.0
 
         with pytest.raises(ValueError, match=r".*accepted dimension.*"):
             out_store.write_output_vars(0)
@@ -83,7 +83,7 @@ class TestZarrOutputStore:
         _bind_state(model)
         out_store = ZarrOutputStore(in_dataset, model, None)
 
-        model.store[("init_profile", "x")] = np.array([1.0, 2.0, 3.0])
+        model.state[("init_profile", "x")] = np.array([1.0, 2.0, 3.0])
 
         out_store.write_index_vars()
         ztest = zarr.open_group(out_store.zgroup.store, mode="r")
@@ -105,7 +105,7 @@ class TestZarrOutputStore:
         out_store = ZarrOutputStore(in_ds, model, None)
 
         for step, size in zip([0, 1, 2], [1, 3, 2]):
-            model.store[("p", "arr")] = np.ones(size)
+            model.state[("p", "arr")] = np.ones(size)
             out_store.write_output_vars(step)
 
         ztest = zarr.open_group(out_store.zgroup.store, mode="r")
@@ -119,9 +119,9 @@ class TestZarrOutputStore:
         _bind_state(model)
         out_store = ZarrOutputStore(in_dataset, model, None)
 
-        model.store[("profile", "u")] = np.array([1.0, 2.0, 3.0])
-        model.store[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
-        model.store[("add", "offset")] = 2.0
+        model.state[("profile", "u")] = np.array([1.0, 2.0, 3.0])
+        model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
+        model.state[("add", "offset")] = 2.0
 
         out_store.write_output_vars(0)
 
@@ -132,9 +132,9 @@ class TestZarrOutputStore:
         _bind_state(model)
         out_store = ZarrOutputStore(in_dataset, model, mkdtemp())
 
-        model.store[("profile", "u")] = np.array([1.0, 2.0, 3.0])
-        model.store[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
-        model.store[("add", "offset")] = 2.0
+        model.state[("profile", "u")] = np.array([1.0, 2.0, 3.0])
+        model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
+        model.state[("add", "offset")] = 2.0
 
         out_store.write_output_vars(0)
 

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -10,12 +10,12 @@ import xsimlab as xs
 from xsimlab.stores import ZarrOutputStore
 
 
-def _bind_store(model):
-    store = {}
-    model.store = store
+def _bind_state(model):
+    state = {}
+    model.store = state
 
     for p_obj in model.values():
-        p_obj.__xsimlab_store__ = store
+        p_obj.__xsimlab_state__ = state
 
 
 class TestZarrOutputStore:
@@ -39,7 +39,7 @@ class TestZarrOutputStore:
         assert not ds.xsimlab.output_vars
 
     def test_write_output_vars(self, in_dataset, model):
-        _bind_store(model)
+        _bind_state(model)
         out_store = ZarrOutputStore(in_dataset, model, None)
 
         model.store[("profile", "u")] = np.array([1.0, 2.0, 3.0])
@@ -69,7 +69,7 @@ class TestZarrOutputStore:
         assert_array_equal(ztest.profile__u_opp, np.array([-1.0, -2.0, -3.0]))
 
     def test_write_output_vars_error(self, in_dataset, model):
-        _bind_store(model)
+        _bind_state(model)
         out_store = ZarrOutputStore(in_dataset, model, None)
 
         model.store[("profile", "u")] = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
@@ -80,7 +80,7 @@ class TestZarrOutputStore:
             out_store.write_output_vars(0)
 
     def test_write_index_vars(self, in_dataset, model):
-        _bind_store(model)
+        _bind_state(model)
         out_store = ZarrOutputStore(in_dataset, model, None)
 
         model.store[("init_profile", "x")] = np.array([1.0, 2.0, 3.0])
@@ -101,7 +101,7 @@ class TestZarrOutputStore:
             model=model, clocks={"clock": [0, 1, 2]}, output_vars={"p__arr": "clock"},
         )
 
-        _bind_store(model)
+        _bind_state(model)
         out_store = ZarrOutputStore(in_ds, model, None)
 
         for step, size in zip([0, 1, 2], [1, 3, 2]):
@@ -116,7 +116,7 @@ class TestZarrOutputStore:
         assert_array_equal(ztest.p__arr, expected)
 
     def test_open_as_xr_dataset(self, in_dataset, model):
-        _bind_store(model)
+        _bind_state(model)
         out_store = ZarrOutputStore(in_dataset, model, None)
 
         model.store[("profile", "u")] = np.array([1.0, 2.0, 3.0])
@@ -129,7 +129,7 @@ class TestZarrOutputStore:
         assert ds.profile__u.chunks is None
 
     def test_open_as_xr_dataset_chunks(self, in_dataset, model):
-        _bind_store(model)
+        _bind_state(model)
         out_store = ZarrOutputStore(in_dataset, model, mkdtemp())
 
         model.store[("profile", "u")] = np.array([1.0, 2.0, 3.0])

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -346,7 +346,7 @@ class TestSimlabAccessor:
     def test_run_safe_mode(self, model, in_dataset):
         # safe mode True: ensure model is cloned
         _ = in_dataset.xsimlab.run(model=model, safe_mode=True)
-        assert model.profile.__xsimlab_store__ is None
+        assert model.profile.__xsimlab_state__ is None
 
         # safe mode False: model not cloned -> original model is used
         _ = in_dataset.xsimlab.run(model=model, safe_mode=False)

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -717,12 +717,12 @@ class SimlabAccessor:
         if safe_mode:
             model = model.clone()
 
-        store = {}
+        state = {}
 
         driver = XarraySimulationDriver(
             self._ds,
             model,
-            store,
+            state,
             output_store,
             check_dims=check_dims,
             validate=validate,

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -644,7 +644,7 @@ class SimlabAccessor:
         model=None,
         check_dims="strict",
         validate="inputs",
-        output_store=None,
+        store=None,
         hooks=None,
         safe_mode=True,
     ):
@@ -678,13 +678,13 @@ class SimlabAccessor:
             The latter may significantly impact performance, but it may be
             useful for debugging.
             If None is given, no validation is performed.
-        output_store : str or :class:`zarr.Group` object, optional
-            If a string (path) is given, output simulation data
+        store : str or :class:`collections.abc.MutableMapping` or :class:`zarr.Group` object, optional
+            If a string (path) is given, simulation I/O data
             will be saved in that specified directory in the file
-            system. If None is given (default), all output data
-            will be saved in memory. This parameter also directly
-            accepts a zarr group object or (most of) zarr store
-            objects for more storage options (see notes below).
+            system. If None is given (default), all data will be saved in
+            memory. This parameter also directly accepts a zarr group object
+            or (most of) zarr store objects for more storage options
+            (see notes below).
         hooks : list, optional
             One or more runtime hooks, i.e., functions decorated with
             :func:`~xsimlab.runtime_hook` or instances of
@@ -723,7 +723,7 @@ class SimlabAccessor:
             self._ds,
             model,
             state,
-            output_store,
+            store,
             check_dims=check_dims,
             validate=validate,
             hooks=hooks,


### PR DESCRIPTION
 - [x] Closes #96
 - [x] Passes `black . && flake8`

`store` (now `state`) is just a dictionary that maps a model variable to its current value.
`output_store` (now `store`) stores both input and output simulation data.