### PR TITLE
Add encoding options for storing model variables 

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -70,7 +70,8 @@ Enhancements
   :class:`~xsimlab.RuntimeHook` class.
 - Added some useful properties and methods to the ``xarray.Dataset.xsimlab``
   extension (:issue:`103`).
-- Save model inputs/outputs using zarr (:issue:`102`, :issue:`111`).
+- Save model inputs/outputs using zarr (:issue:`102`, :issue:`111`,
+  :issue:`113`).
 - Added :class:`~xsimlab.monitoring.ProgressBar` to track simulation progress
   (:issue:`104`, :issue:`110`).
 

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -175,6 +175,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
         model,
         state,
         store,
+        encoding,
         check_dims=CheckDimsOption.STRICT,
         validate=ValidateOption.INPUTS,
         hooks=None,
@@ -204,7 +205,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
         hooks = set(hooks) | RuntimeHook.active
         self._hooks = group_hooks(flatten_hooks(hooks))
 
-        self.store = ZarrSimulationStore(dataset, model, store)
+        self.store = ZarrSimulationStore(dataset, model, store, encoding)
 
     def _check_missing_model_inputs(self):
         """Check if all model inputs have their corresponding variables

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -110,7 +110,7 @@ class ZarrSimulationStore:
     def _cache_value_as_array(self, var_key):
         value = self.var_info[var_key]["value_getter"]()
 
-        if np.isscalar(value):
+        if np.isscalar(value) or isinstance(value, (list, tuple)):
             value = np.asarray(value)
 
         self.var_info[var_key]["value"] = value

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -5,8 +5,9 @@ import numpy as np
 import xarray as xr
 import zarr
 
-from xsimlab import Model
-from xsimlab.process import variables_dict
+from . import Model
+from .process import variables_dict
+from .utils import normalize_encoding
 
 
 _DIMENSION_KEY = "_ARRAY_DIMENSIONS"
@@ -19,7 +20,9 @@ def _variable_value_getter(process_obj: Any, var_name: str) -> Callable:
     return value_getter
 
 
-def _get_var_info(dataset: xr.Dataset, model: Model) -> Dict[Tuple[str, str], Dict]:
+def _get_var_info(
+    dataset: xr.Dataset, model: Model, encoding: Dict[str, Dict[str, Any]]
+) -> Dict[Tuple[str, str], Dict]:
     var_info = {}
 
     var_clocks = {k: v for k, v in dataset.xsimlab.output_vars.items()}
@@ -27,16 +30,21 @@ def _get_var_info(dataset: xr.Dataset, model: Model) -> Dict[Tuple[str, str], Di
 
     for var_key, clock in var_clocks.items():
         p_name, v_name = var_key
+        v_name_str = f"{p_name}__{v_name}"
         p_obj = model[p_name]
         v_obj = variables_dict(type(p_obj))[v_name]
 
+        v_encoding = v_obj.metadata["encoding"]
+        v_encoding.update(normalize_encoding(encoding.get(v_name_str)))
+
         var_info[var_key] = {
             "clock": clock,
-            "name": f"{p_name}__{v_name}",
+            "name": v_name_str,
             "obj": v_obj,
             "value_getter": _variable_value_getter(p_obj, v_name),
             "value": None,
             "shape": None,
+            "encoding": v_encoding,
         }
 
     return var_info
@@ -60,6 +68,7 @@ class ZarrSimulationStore:
         dataset: xr.Dataset,
         model: Model,
         zobject: Union[zarr.Group, MutableMapping, str, None],
+        encoding: Union[Dict[str, Dict[str, Any]], None],
     ):
         self.dataset = dataset
         self.model = model
@@ -78,7 +87,10 @@ class ZarrSimulationStore:
         self.output_vars = dataset.xsimlab.output_vars_by_clock
         self.output_save_steps = dataset.xsimlab.get_output_save_steps()
 
-        self.var_info = _get_var_info(dataset, model)
+        if encoding is None:
+            encoding = {}
+
+        self.var_info = _get_var_info(dataset, model, encoding)
 
         self.mclock_dim = dataset.xsimlab.master_clock_dim
         self.clock_sizes = dataset.xsimlab.clock_sizes
@@ -120,22 +132,22 @@ class ZarrSimulationStore:
         # init shape for dynamically sized arrays
         self.var_info[var_key]["shape"] = np.asarray(shape)
 
-        chunks = True
-        compressor = "default"
+        zkwargs = {
+            "shape": shape,
+            "chunks": True,
+            "dtype": array.dtype,
+            "compressor": "default",
+            "fill_value": default_fill_value_from_dtype(array.dtype),
+        }
+
+        zkwargs.update(self.var_info[var_key]["encoding"])
 
         # TODO: more performance assessment
         # if self.in_memory:
         #     chunks = False
         #     compressor = None
 
-        zdataset = self.zgroup.create_dataset(
-            name,
-            shape=shape,
-            chunks=chunks,
-            dtype=array.dtype,
-            compressor=compressor,
-            fill_value=default_fill_value_from_dtype(array.dtype),
-        )
+        zdataset = self.zgroup.create_dataset(name, **zkwargs)
 
         # add dimension labels and variable attributes as metadata
         dim_labels = None

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -89,6 +89,7 @@ def in_var_details():
     - groups : ()
     - static : False
     - attrs : {}
+    - encoding : {}
     """
     )
 

--- a/xsimlab/tests/test_drivers.py
+++ b/xsimlab/tests/test_drivers.py
@@ -20,7 +20,7 @@ def base_driver(model):
 @pytest.fixture
 def xarray_driver(in_dataset, model):
     state = {}
-    return XarraySimulationDriver(in_dataset, model, state, None)
+    return XarraySimulationDriver(in_dataset, model, state, None, None)
 
 
 def test_runtime_context():
@@ -92,12 +92,12 @@ class TestXarraySimulationDriver:
 
         invalid_ds = in_dataset.drop("clock")
         with pytest.raises(ValueError) as excinfo:
-            XarraySimulationDriver(invalid_ds, model, state, None)
+            XarraySimulationDriver(invalid_ds, model, state, None, None)
         assert "Missing master clock" in str(excinfo.value)
 
         invalid_ds = in_dataset.drop("init_profile__n_points")
         with pytest.raises(KeyError) as excinfo:
-            XarraySimulationDriver(invalid_ds, model, state, None)
+            XarraySimulationDriver(invalid_ds, model, state, None, None)
         assert "Missing variables" in str(excinfo.value)
 
     @pytest.mark.parametrize(
@@ -142,7 +142,7 @@ class TestXarraySimulationDriver:
 
         m = model.update_processes({"p": P})
 
-        driver = XarraySimulationDriver(in_dataset, m, {}, None)
+        driver = XarraySimulationDriver(in_dataset, m, {}, None, None)
 
         with pytest.raises(KeyError, match="'not_a_runtime_arg'"):
             driver.run_model()

--- a/xsimlab/tests/test_formatting.py
+++ b/xsimlab/tests/test_formatting.py
@@ -80,6 +80,7 @@ def test_add_attribute_section():
         - groups : ()
         - static : False
         - attrs : {}
+        - encoding : {}
 
     var2 : object
         (no description given)
@@ -90,6 +91,7 @@ def test_add_attribute_section():
         - groups : ()
         - static : False
         - attrs : {}
+        - encoding : {}
 
 """
 

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -120,7 +120,7 @@ class TestZarrSimulationStore:
         class P:
             v1 = xs.variable(dims="x", intent="out", encoding={"chunks": (10,)})
             v2 = xs.on_demand(dims="x", encoding={"fill_value": 0})
-            v3 = xs.index(dims="x", encoding={"compressor": None})
+            v3 = xs.index(dims="x")
 
             @v2.compute
             def _get_v2(self):
@@ -136,7 +136,10 @@ class TestZarrSimulationStore:
 
         _bind_state(model)
         out_store = ZarrSimulationStore(
-            in_ds, model, None, {"p__v2": {"fill_value": -1}}
+            in_ds,
+            model,
+            None,
+            {"p__v2": {"fill_value": -1}, "p__v3": {"compressor": None}},
         )
 
         model.state[("p", "v1")] = [0]

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -23,12 +23,12 @@ class TestZarrSimulationStore:
         "zobject", [None, mkdtemp(), zarr.MemoryStore(), zarr.group()]
     )
     def test_constructor(self, in_dataset, model, zobject):
-        out_store = ZarrSimulationStore(in_dataset, model, zobject)
+        out_store = ZarrSimulationStore(in_dataset, model, zobject, None)
 
         assert out_store.zgroup.store is not None
 
     def test_write_input_xr_dataset(self, in_dataset, model):
-        out_store = ZarrSimulationStore(in_dataset, model, None)
+        out_store = ZarrSimulationStore(in_dataset, model, None, None)
 
         out_store.write_input_xr_dataset()
         ds = xr.open_zarr(out_store.zgroup.store, chunks=None)
@@ -40,7 +40,7 @@ class TestZarrSimulationStore:
 
     def test_write_output_vars(self, in_dataset, model):
         _bind_state(model)
-        out_store = ZarrSimulationStore(in_dataset, model, None)
+        out_store = ZarrSimulationStore(in_dataset, model, None, None)
 
         model.state[("profile", "u")] = np.array([1.0, 2.0, 3.0])
         model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
@@ -70,7 +70,7 @@ class TestZarrSimulationStore:
 
     def test_write_output_vars_error(self, in_dataset, model):
         _bind_state(model)
-        out_store = ZarrSimulationStore(in_dataset, model, None)
+        out_store = ZarrSimulationStore(in_dataset, model, None, None)
 
         model.state[("profile", "u")] = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
@@ -81,7 +81,7 @@ class TestZarrSimulationStore:
 
     def test_write_index_vars(self, in_dataset, model):
         _bind_state(model)
-        out_store = ZarrSimulationStore(in_dataset, model, None)
+        out_store = ZarrSimulationStore(in_dataset, model, None, None)
 
         model.state[("init_profile", "x")] = np.array([1.0, 2.0, 3.0])
 
@@ -102,7 +102,7 @@ class TestZarrSimulationStore:
         )
 
         _bind_state(model)
-        out_store = ZarrSimulationStore(in_ds, model, None)
+        out_store = ZarrSimulationStore(in_ds, model, None, None)
 
         for step, size in zip([0, 1, 2], [1, 3, 2]):
             model.state[("p", "arr")] = np.ones(size)
@@ -117,7 +117,7 @@ class TestZarrSimulationStore:
 
     def test_open_as_xr_dataset(self, in_dataset, model):
         _bind_state(model)
-        out_store = ZarrSimulationStore(in_dataset, model, None)
+        out_store = ZarrSimulationStore(in_dataset, model, None, None)
 
         model.state[("profile", "u")] = np.array([1.0, 2.0, 3.0])
         model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])
@@ -130,7 +130,7 @@ class TestZarrSimulationStore:
 
     def test_open_as_xr_dataset_chunks(self, in_dataset, model):
         _bind_state(model)
-        out_store = ZarrSimulationStore(in_dataset, model, mkdtemp())
+        out_store = ZarrSimulationStore(in_dataset, model, mkdtemp(), None)
 
         model.state[("profile", "u")] = np.array([1.0, 2.0, 3.0])
         model.state[("roll", "u_diff")] = np.array([-1.0, 1.0, 0.0])

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -126,7 +126,7 @@ class TestZarrSimulationStore:
             def _get_v2(self):
                 return [0]
 
-        model = xs.Model({'p': P})
+        model = xs.Model({"p": P})
 
         in_ds = xs.create_setup(
             model=model,

--- a/xsimlab/tests/test_utils.py
+++ b/xsimlab/tests/test_utils.py
@@ -36,6 +36,25 @@ def test_import_required():
     assert err_msg in str(excinfo.value)
 
 
+def test_normalize_encoding():
+    assert utils.normalize_encoding(None) == {}
+
+    encoding = {
+        "chunks": True,
+        "dtype": "int",
+        "compressor": None,
+        "fill_value": 0,
+        "order": "C",
+        "filters": None,
+        "object_codec": None,
+        "ignored_key": None,
+    }
+
+    actual = utils.normalize_encoding(encoding)
+    encoding.pop("ignored_key")
+    assert actual == encoding
+
+
 class TestAttrMapping:
     @pytest.fixture
     def attr_mapping(self):

--- a/xsimlab/utils.py
+++ b/xsimlab/utils.py
@@ -44,6 +44,23 @@ def import_required(mod_name, error_msg):
         raise RuntimeError(error_msg)
 
 
+def normalize_encoding(encoding):
+    used_keys = [
+        "chunks",
+        "dtype",
+        "compressor",
+        "fill_value",
+        "order",
+        "filters",
+        "object_codec",
+    ]
+
+    if encoding is None:
+        return {}
+    else:
+        return {k: v for k, v in encoding if k in used_keys}
+
+
 class AttrMapping:
     """A class similar to `collections.abc.Mapping`,
     which also allows getting keys with attribute access.

--- a/xsimlab/utils.py
+++ b/xsimlab/utils.py
@@ -58,7 +58,7 @@ def normalize_encoding(encoding):
     if encoding is None:
         return {}
     else:
-        return {k: v for k, v in encoding if k in used_keys}
+        return {k: v for k, v in encoding.items() if k in used_keys}
 
 
 class AttrMapping:

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -5,6 +5,8 @@ import warnings
 import attr
 from attr._make import _CountingAttr
 
+from .utils import normalize_encoding
+
 
 class VarType(Enum):
     VARIABLE = "variable"
@@ -91,23 +93,6 @@ def _as_group_tuple(groups, group):
             groups.append(group)
 
     return tuple(groups)
-
-
-def _normalize_encoding(encoding):
-    used_keys = [
-        "chunks",
-        "dtype",
-        "compressor",
-        "fill_value",
-        "order",
-        "filters",
-        "object_codec",
-    ]
-
-    if encoding is None:
-        return {}
-    else:
-        return {k: v for k, v in encoding if k in used_keys}
 
 
 def variable(
@@ -209,7 +194,7 @@ def variable(
         "static": static,
         "attrs": attrs or {},
         "description": description,
-        "encoding": _normalize_encoding(encoding),
+        "encoding": normalize_encoding(encoding),
     }
 
     if VarIntent(intent) == VarIntent.OUT:
@@ -280,7 +265,7 @@ def index(dims, groups=None, description="", attrs=None, encoding=None):
         "groups": _as_group_tuple(groups, None),
         "attrs": attrs or {},
         "description": description,
-        "encoding": _normalize_encoding(encoding),
+        "encoding": normalize_encoding(encoding),
     }
 
     return attr.attrib(metadata=metadata, init=False, repr=False)
@@ -344,7 +329,7 @@ def on_demand(
         "groups": _as_group_tuple(groups, group),
         "attrs": attrs or {},
         "description": description,
-        "encoding": _normalize_encoding(encoding),
+        "encoding": normalize_encoding(encoding),
     }
 
     return attr.attrib(metadata=metadata, init=False, repr=False)

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -645,6 +645,7 @@ class SimlabAccessor:
         check_dims="strict",
         validate="inputs",
         store=None,
+        encoding=None,
         hooks=None,
         safe_mode=True,
     ):
@@ -685,6 +686,13 @@ class SimlabAccessor:
             memory. This parameter also directly accepts a zarr group object
             or (most of) zarr store objects for more storage options
             (see notes below).
+        encoding : dict, optional
+            Nested dictionary with variable names as keys and dictionaries of
+            variable specific encodings as values, e.g.,
+            ``{'my_variable': {'dtype': 'int16', 'fill_value': -9999,}, ...}``.
+            See the ``encoding`` parameter of :func:`~xsimlab.variable`.
+            Encoding options provided here override encoding options defined in
+            model variables.
         hooks : list, optional
             One or more runtime hooks, i.e., functions decorated with
             :func:`~xsimlab.runtime_hook` or instances of
@@ -724,6 +732,7 @@ class SimlabAccessor:
             model,
             state,
             store,
+            encoding,
             check_dims=check_dims,
             validate=validate,
             hooks=hooks,


### PR DESCRIPTION
 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This adds the possibility to define some `zarr.creation.create` arguments both at model variable declaration and when calling `Dataset.xsimlab.run()`. Options supplied in the latter override options defined in variables.