### PR TITLE
Accept array-like input vars with no dimension labels

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,6 +10,10 @@ Enhancements
 ~~~~~~~~~~~~
 
 - Added :attr:`xsimlab.Model.cache` public property (:issue:`125`).
+- Parameter ``input_vars`` of :func:`~xsimlab.create_setup` and
+  :func:`xarray.Dataset.xsimlab.update_vars` now accepts array-like values
+  with no explicit dimension label(s), in this case those labels are inferred
+  from model variables' metadata (:issue:`126`).
 
 Bug fixes
 ~~~~~~~~~

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -207,7 +207,7 @@ class TestSimlabAccessor:
         in_vars = {("add", "offset"): [1, 2, 3, 4, 5]}
         ds.xsimlab._set_input_vars(model, in_vars)
 
-        assert ds["add__offset"].dims == ('x',)
+        assert ds["add__offset"].dims == ("x",)
 
     def test_update_clocks(self, model):
         ds = xr.Dataset()

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -196,11 +196,18 @@ class TestSimlabAccessor:
             xr.testing.assert_equal(ds[vname], in_dataset[vname])
             assert ds[vname].attrs == in_dataset[vname].attrs
 
+        # test errors
         in_vars[("not_an", "input_var")] = None
 
         with pytest.raises(KeyError) as excinfo:
             ds.xsimlab._set_input_vars(model, in_vars)
         assert "not valid key(s)" in str(excinfo.value)
+
+        # test implicit dimension label
+        in_vars = {("add", "offset"): [1, 2, 3, 4, 5]}
+        ds.xsimlab._set_input_vars(model, in_vars)
+
+        assert ds["add__offset"].dims == ('x',)
 
     def test_update_clocks(self, model):
         ds = xr.Dataset()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
