### PR TITLE
"Stateless" process executors

### DIFF
--- a/ci/requirements/doc.yml
+++ b/ci/requirements/doc.yml
@@ -12,6 +12,7 @@ dependencies:
   - pip:
       - attrs==19.2.0
       - dask==2.11.0
+      - distributed==2.11.0
       - ipython==7.8.0
       - matplotlib==3.0.2
       - nbconvert==5.6.0

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -14,9 +14,8 @@ Enhancements
   :func:`xarray.Dataset.xsimlab.update_vars` now accepts array-like values
   with no explicit dimension label(s), in this case those labels are inferred
   from model variables' metadata (:issue:`126`).
-- It is now possible to use Dask's multi-processes or distributed schedulers
-  for single-model parallelism, although this is not often optimal and
-  still has limitations (:issue:`127`).
+- Single-model parallelism now supports Dask's multi-processes or distributed
+  schedulers, although this is still limited and rarely optimal (:issue:`127`).
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -14,6 +14,9 @@ Enhancements
   :func:`xarray.Dataset.xsimlab.update_vars` now accepts array-like values
   with no explicit dimension label(s), in this case those labels are inferred
   from model variables' metadata (:issue:`126`).
+- It is now possible to use Dask's multi-processes or distributed schedulers
+  for single-model parallelism, although this is not often optimal and
+  still has limitations (:issue:`127`).
 
 Bug fixes
 ~~~~~~~~~

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -743,6 +743,7 @@ class Model(AttrMapping):
         be passed to a Dask scheduler.
 
         """
+
         def exec_process(p_obj, model_state, out_states):
             # update model state with output state from all dependent processes
             state = {}

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -4,7 +4,7 @@ import time
 
 import attr
 import dask
-import distributed
+from dask.distributed import Client
 
 from .variable import VarIntent, VarType
 from .process import (
@@ -841,7 +841,7 @@ class Model(AttrMapping):
 
             # TODO: without this -> flaky tests (don't know why)
             # state is not well updated -> error when writing output vars in store
-            if isinstance(scheduler, distributed.Client):
+            if isinstance(scheduler, Client):
                 time.sleep(0.001)
 
             self._gather_and_update_state(out_states)

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -721,30 +721,47 @@ class Model(AttrMapping):
         for h in event_hooks:
             h(self, Frozen(runtime_context), Frozen(self.state))
 
-    def _execute_process(self, p_obj, stage, runtime_context, hooks, validate):
+    def _execute_process(self, p_obj, stage, runtime_context, hooks, validate, state=None):
         executor = p_obj.__xsimlab_executor__
         p_name = p_obj.__xsimlab_name__
 
         self._call_hooks(hooks, runtime_context, stage, "process", "pre")
-        executor.execute(p_obj, stage, runtime_context)
+        out_state = executor.execute(p_obj, stage, runtime_context, state=state)
         self._call_hooks(hooks, runtime_context, stage, "process", "post")
 
         if validate:
             self.validate(self._processes_to_validate[p_name])
 
+        return p_name, out_state
+
     def _build_dask_graph(self, extra_args):
-        def exec_process(p_obj, deps):
-            self._execute_process(p_obj, *extra_args)
+        def exec_process(p_obj, model_state, out_states):
+            state = {}
+            state.update(model_state)
+            for _, s in out_states:
+                state.update(s)
 
-        dsk = {
-            p_name: (exec_process, self._processes[p_name], p_deps)
-            for p_name, p_deps in self._dep_processes.items()
-        }
+            return self._execute_process(p_obj, *extra_args, state=state)
 
-        # add a dummy node so that we properly call the get func of dask scheduler
-        dsk["_end"] = (lambda deps: None, list(self._processes))
+        dsk = {}
+        for p_name, p_deps in self._dep_processes.items():
+            dsk[p_name] = (exec_process, self._processes[p_name], self._state, p_deps)
+
+        # add a dummy node to merge state from all executed processes
+        dsk["_gather"] = (lambda out_states: dict(out_states), list(self._processes))
 
         return dsk
+
+    def _gather_and_update_state(self, out_states):
+        new_state = {}
+
+        for p_name in self._processes:
+            new_state.update(out_states[p_name])
+
+        self._state.update(new_state)
+
+        for p_obj in self._processes.values():
+            p_obj.__xsimlab_state__ = self._state
 
     def execute(
         self,
@@ -806,17 +823,20 @@ class Model(AttrMapping):
             dsk_get = dask.threaded.get
 
         stage = SimulationStage(stage)
-        extra_args = (stage, runtime_context, hooks, validate)
+        execute_args = (stage, runtime_context, hooks, validate)
 
         self._call_hooks(hooks, runtime_context, stage, "model", "pre")
 
         if parallel:
-            dsk = self._build_dask_graph(extra_args)
-            dsk_get(dsk, "_end", scheduler=scheduler)
+            dsk = self._build_dask_graph(execute_args)
+            out_states = dsk_get(dsk, "_gather", scheduler=scheduler)
+            self._gather_and_update_state(out_states)
+            import time
+            time.sleep(0.001)
 
         else:
             for p_name, p_obj in self._processes.items():
-                self._execute_process(p_obj, *extra_args)
+                self._execute_process(p_obj, *execute_args)
 
         self._call_hooks(hooks, runtime_context, stage, "model", "post")
 

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -723,7 +723,9 @@ class Model(AttrMapping):
         for h in event_hooks:
             h(self, Frozen(runtime_context), Frozen(self.state))
 
-    def _execute_process(self, p_obj, stage, runtime_context, hooks, validate, state=None):
+    def _execute_process(
+        self, p_obj, stage, runtime_context, hooks, validate, state=None
+    ):
         executor = p_obj.__xsimlab_executor__
         p_name = p_obj.__xsimlab_name__
 
@@ -812,9 +814,13 @@ class Model(AttrMapping):
           in the process classes must be thread-safe. Also, it should release
           the Python Global Interpreted Lock (GIL) as much as possible in order
           to see a gain in performance.
-        - Multi-process or distributed schedulers are not supported, as
-          currently the model state (shared between the process classes)
-          is stored using a simple Python dictionary.
+        - Multi-process or distributed schedulers may have very poor performance,
+          especially when a lot of data (model state) is shared between the model
+          processes. The way xarray-simlab scatters/gathers this data between the
+          scheduler and the workers is not optimized at all. Addtionally, those
+          schedulers may not work well with the given ``hooks`` and/or when the
+          processes runtime methods rely on instance attributes that are not
+          explicitly declared as model variables.
 
         """
         if hooks is None:

--- a/xsimlab/tests/__init__.py
+++ b/xsimlab/tests/__init__.py
@@ -22,4 +22,4 @@ if os.environ.get("DASK_SINGLE_THREADED"):
     use_dask_schedulers = ["single-threaded"]
 else:
     # Still useful to test threads/processes (pickle issues) locally
-    use_dask_schedulers = ["threads", "processes", "distributed"]
+    use_dask_schedulers = ["threads", "processes", "distributed", "distributed-threads"]

--- a/xsimlab/tests/test_process.py
+++ b/xsimlab/tests/test_process.py
@@ -204,7 +204,6 @@ def test_process_properties_converter(processes_with_state):
 
 
 def test_runtime_decorator_noargs():
-
     class P:
         @xs.runtime
         def meth(self):
@@ -220,7 +219,6 @@ def test_runtime_decorator_noargs():
 
 @pytest.mark.parametrize("args", ["p1,p2", ["p1", "p2"], ("p1", "p2")])
 def test_runtime_decorator(args):
-
     class P:
         @xs.runtime(args=args)
         def meth(self, a, b):
@@ -248,7 +246,6 @@ def test_runtime_decorator_raise():
 
 
 def test_runtime_function():
-
     class P:
         def meth(self):
             self.v = 1

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -400,15 +400,6 @@ class TestSimlabAccessor:
         assert ds.xsimlab.output_vars_by_clock == expected
 
     def test_run(self, model, in_dataset, out_dataset, parallel, scheduler):
-        is_proc_scheduler = (
-            scheduler == "processes"
-            or isinstance(scheduler, Client)
-            and scheduler.cluster.processes
-        )
-
-        #if parallel and is_proc_scheduler:
-        #    pytest.skip("multi-processes schedulers not supported for one run")
-
         @xs.process
         class ProfileFix(Profile):
             # limitation of using distributed for single-model parallelism
@@ -418,9 +409,7 @@ class TestSimlabAccessor:
 
         m = model.update_processes({"profile": ProfileFix})
 
-        out_ds = in_dataset.xsimlab.run(
-            model=m, parallel=parallel, scheduler=scheduler
-        )
+        out_ds = in_dataset.xsimlab.run(model=m, parallel=parallel, scheduler=scheduler)
 
         xr.testing.assert_equal(out_ds.load(), out_dataset)
 

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -778,10 +778,11 @@ class SimlabAccessor:
         - The code implemented in the process classes of ``model`` must be
           thread-safe if a dask multi-threaded scheduler is used, and must be
           serializable if a multi-process or distributed scheduler is used.
-        - Multi-process or distributed schedulers are not supported when running
-          the ``model`` processes in parallel (i.e., one simulation), as currently
-          ``model`` state (shared between its processes) is stored using a simple
-          Python dictionary.
+        - Multi-process or distributed schedulers are not well supported or
+          may have poor performance when running the ``model`` processes in
+          parallel (i.e., single-model parallelism), depending on the amount
+          of data shared between the processes. See :meth:`xsimlab.Model.execute`
+          for more details.
         - Not all zarr stores are safe to write in multiple threads or processes.
           For example, :class:`zarr.storage.MemoryStore` used by default is
           safe to write in multiple threads but not in multiple processes.


### PR DESCRIPTION
This allows using Dask's processes and distributed schedulers for single-model parallelism, although those may not yield good performance when a lot of data is shared between the processes (model state). Support of those schedulers is still limited, i.e.,

- doesn't work well with ``hooks``
- doesn't work at all for attributes in process classes that are used in runtime methods but that are not declared as variables (i.e., not part of a model's state)
- doesn't work when ``validate='all'`` (validate foreign variables). 

The new design (only used for parallel runs): 

A process executor returns a dictionary that consists of a subset of its state dictionary with only its output variables (intent 'in' or 'inout'). The executor also accepts a state dictionary as an optional input argument, which overwrites the current one attached to the process instance.

This is useful when building dask custom graphs with "stateless" nodes. Each process (graph node) collects the states returned by its dependent processes, which are merged with the model current state before passing it to the process executor as input. An additional (final) task gathers the states returned from all process executors, which are then merged together before updating the model state for the next stage.

That's not ideal, somewhat convoluted, and not optimal, but it works without the need of a more significant refactoring (and it doesn't look that bad).   

 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
