### PR TITLE
Avoid using attr non-public API

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,7 @@ Bug fixes
 
 - Fix running batches of simulations using ``dask.distributed`` (:issue:`124`).
 - Fix rendering of auto-generated docstrings of process classes (:issue:`128`).
+- Fix tests with ``attr`` v20.1.0 (:issue:`129`).
 
 v0.4.0 (7 April 2020)
 ---------------------

--- a/xsimlab/tests/test_validators.py
+++ b/xsimlab/tests/test_validators.py
@@ -10,6 +10,7 @@ def simple_attr():
     """
     Return an attribute with a name just for testing purpose.
     """
+
     @attr.attrs
     class C:
         test = attr.attrib()


### PR DESCRIPTION
Fix tests with ``attr`` v20.1.0.

 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
