### PR TITLE
Improve auto-generated docstrings of process variables

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -16,6 +16,8 @@ Enhancements
   from model variables' metadata (:issue:`126`).
 - Single-model parallelism now supports Dask's multi-processes or distributed
   schedulers, although this is still limited and rarely optimal (:issue:`127`).
+- Improved auto-generated docstrings of variables declared in process classes
+  (:issue:`130`).
 
 Bug fixes
 ~~~~~~~~~

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -85,13 +85,11 @@ def in_var_details():
         """\
     Input variable
 
-    - type : variable
-    - intent : in
-    - dims : (('x',), ('x', 'y'))
-    - groups : ()
-    - static : False
-    - attrs : {}
-    - encoding : {}
+    Variable properties:
+
+    - type : ``variable``
+    - intent : ``in``
+    - dimensions : ('x',) or ('x', 'y')
     """
     )
 

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -407,10 +407,12 @@ def foreign(other_process_cls, var_name, intent="in"):
         "other_process_cls": other_process_cls,
         "var_name": var_name,
         "intent": VarIntent(intent),
-        "description": ref_var.metadata["description"],
-        "attrs": ref_var.metadata.get("attrs", {}),
-        "encoding": ref_var.metadata.get("encoding", {}),
     }
+
+    for meta_key in ["description", "dims", "attrs", "encoding"]:
+        ref_value = ref_var.metadata.get(meta_key)
+        if ref_value is not None:
+            metadata[meta_key] = ref_value
 
     if VarIntent(intent) == VarIntent.OUT:
         _init = False


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
