### PR TITLE
Fix saving output variables with dtype=object

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,6 +6,11 @@ Release Notes
 v0.5.0 (Unreleased)
 -------------------
 
+Bug fixes
+~~~~~~~~~
+
+- Fix saving output variables with dtype=object (:issue:`145`).
+
 v0.4.1 (17 April 2020)
 ----------------------
 

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -73,8 +73,8 @@ def default_fill_value_from_dtype(dtype=None):
 
 def get_auto_chunks(shape, dtype):
     # A hack to get chunks guessed by zarr
-    if(dtype == object or dtype == np.object):
-        arr = zarr.create(shape, dtype=dtype, object_codec=numcodecs.JSON())
+    if dtype == object:
+        arr = zarr.create(shape, dtype=dtype, object_codec=zarr.codecs.Pickle())
     else:
         arr = zarr.create(shape, dtype=dtype)
     return arr.chunks

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -73,7 +73,10 @@ def default_fill_value_from_dtype(dtype=None):
 
 def get_auto_chunks(shape, dtype):
     # A hack to get chunks guessed by zarr
-    arr = zarr.create(shape, dtype=dtype)
+    if(dtype == object or dtype == np.object):
+        arr = zarr.create(shape, dtype=dtype, object_codec=numcodecs.JSON())
+    else:
+        arr = zarr.create(shape, dtype=dtype)
     return arr.chunks
 
 

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -220,7 +220,11 @@ class TestZarrSimulationStore:
             v1 = xs.variable(dims="x", intent="out", encoding={"dtype": np.int32})
             v2 = xs.on_demand(dims="x", encoding={"fill_value": 0})
             v3 = xs.index(dims="x")
-            v4 = xs.variable(dims="x", intent="out", encoding={"dtype": object, "object_codec": zarr.codecs.Pickle()})
+            v4 = xs.variable(
+                dims="x",
+                intent="out",
+                encoding={"dtype": object, "object_codec": zarr.codecs.Pickle()},
+            )
 
             @v2.compute
             def _get_v2(self):
@@ -242,7 +246,7 @@ class TestZarrSimulationStore:
 
         model.state[("p", "v1")] = [0]
         model.state[("p", "v3")] = [0]
-        model.state[("p", "v4")] = [{'foo': 'bar'}]
+        model.state[("p", "v4")] = [{"foo": "bar"}]
         store.write_output_vars(-1, -1)
 
         ztest = zarr.open_group(store.zgroup.store, mode="r")
@@ -251,7 +255,7 @@ class TestZarrSimulationStore:
         # test encoding precedence ZarrSimulationStore > model variable
         assert ztest.p__v2.fill_value == -1
         assert ztest.p__v3.chunks == (10,)
-        assert ztest.p__v4[0] == {'foo': 'bar'}
+        assert ztest.p__v4[0] == {"foo": "bar"}
 
     def test_open_as_xr_dataset(self, store):
         model = store.model

--- a/xsimlab/tests/test_stores.py
+++ b/xsimlab/tests/test_stores.py
@@ -5,6 +5,7 @@ import zarr
 
 import xsimlab as xs
 from xsimlab.stores import DummyLock, ZarrSimulationStore
+from zarr.util import object_codecs
 
 
 @pytest.fixture(params=["directory", zarr.MemoryStore])
@@ -219,6 +220,7 @@ class TestZarrSimulationStore:
             v1 = xs.variable(dims="x", intent="out", encoding={"dtype": np.int32})
             v2 = xs.on_demand(dims="x", encoding={"fill_value": 0})
             v3 = xs.index(dims="x")
+            v4 = xs.variable(dims="x", intent="out", encoding={"dtype": object, "object_codec": zarr.codecs.Pickle()})
 
             @v2.compute
             def _get_v2(self):
@@ -229,7 +231,7 @@ class TestZarrSimulationStore:
         in_ds = xs.create_setup(
             model=model,
             clocks={"clock": [0]},
-            output_vars={"p__v1": None, "p__v2": None, "p__v3": None},
+            output_vars={"p__v1": None, "p__v2": None, "p__v3": None, "p__v4": None},
         )
 
         store = ZarrSimulationStore(
@@ -240,6 +242,7 @@ class TestZarrSimulationStore:
 
         model.state[("p", "v1")] = [0]
         model.state[("p", "v3")] = [0]
+        model.state[("p", "v4")] = [{'foo': 'bar'}]
         store.write_output_vars(-1, -1)
 
         ztest = zarr.open_group(store.zgroup.store, mode="r")
@@ -248,6 +251,7 @@ class TestZarrSimulationStore:
         # test encoding precedence ZarrSimulationStore > model variable
         assert ztest.p__v2.fill_value == -1
         assert ztest.p__v3.chunks == (10,)
+        assert ztest.p__v4[0] == {'foo': 'bar'}
 
     def test_open_as_xr_dataset(self, store):
         model = store.model


### PR DESCRIPTION
…able dtype is object or np.object. It works at runtime and the variable is successfully saved in the Dataset, but it fails at sabing to file Closes #144

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #144
 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
