### PR TITLE
Mask fill values in output dataset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,9 @@ by Jake VanderPlas.
 
     @xs.process
     class GameOfLife:
-        world = xs.variable(dims=('x', 'y'), intent='inout')
+        world = xs.variable(
+            dims=('x', 'y'), intent='inout', encoding={'fill_value': None}
+        )
 
         def run_step(self):
             nbrs_count = sum(

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -35,7 +35,9 @@ by Jake VanderPlas.
        ...:
        ...: @xs.process
        ...: class GameOfLife:
-       ...:     world = xs.variable(dims=('x', 'y'), intent='inout')
+       ...:     world = xs.variable(
+       ...:         dims=('x', 'y'), intent='inout', encoding={'fill_value': None}
+       ...:     )
        ...:
        ...:     def run_step(self):
        ...:         nbrs_count = sum(

--- a/doc/io_storage.rst
+++ b/doc/io_storage.rst
@@ -254,3 +254,11 @@ Encoding options may also be set or overridden when calling
       ...:
 
    In [9]: out_ds.pt__position
+
+.. warning::
+
+   Zarr uses ``0`` as the default fill value for numeric value types. This may
+   badly affect the results, as array elements with the fill value are replaced
+   by NA in the output xarray Dataset. For variables which accept ``0`` as valid
+   values, it is recommended to explicitly provide an alternative ``fill_value``
+   encoding.

--- a/doc/io_storage.rst
+++ b/doc/io_storage.rst
@@ -223,5 +223,8 @@ Encoding options may also be set or overridden when calling
    Zarr uses ``0`` as the default fill value for numeric value types. This may
    badly affect the results, as array elements with the fill value are replaced
    by NA in the output xarray Dataset. For variables which accept ``0`` as a
-   possible (non-missing) value, it is recommended to explicitly provide an
-   alternative ``fill_value`` encoding.
+   possible (non-missing) value, it is highly recommended to explicitly provide
+   another ``fill_value``. Alternatively, it is possible to deactivate this
+   value masking behavior by setting the ``mask_and_scale=False`` option and
+   pass it via the ``decoding`` parameter of
+   :func:`~xarray.Dataset.xsimlab.run`.

--- a/doc/io_storage.rst
+++ b/doc/io_storage.rst
@@ -214,51 +214,14 @@ data.
 
 Those options can be set for variables declared in process classes. See the
 ``encoding`` parameter of :func:`~xsimlab.variable` for all available options.
-In the example below we specify a custom fill value for the ``position``
-variable, which will be used to replace missing values:
-
-.. ipython::
-
-   In [4]: @xs.process
-      ...: class Particles:
-      ...:     position = xs.variable(dims='pt', intent='out',
-      ...:                            encoding={'fill_value': -1.0})
-      ...:
-      ...:     def initialize(self):
-      ...:         self._rng = np.random.default_rng(123)
-      ...:
-      ...:     def run_step(self):
-      ...:         nparticles = self._rng.integers(1, 4)
-      ...:         self.position = self._rng.uniform(0, 10, size=nparticles)
-      ...:
-
-   In [5]: model = xs.Model({'pt': Particles})
-
-   In [6]: with model:
-      ...:     in_ds = xs.create_setup(clocks={'steps': range(4)},
-      ...:                             output_vars={'pt__position': 'steps'})
-      ...:     out_ds = in_ds.xsimlab.run()
-      ...:
-
-   In [7]: out_ds.pt__position
 
 Encoding options may also be set or overridden when calling
-:func:`~xarray.Dataset.xsimlab.run`, e.g.,
-
-.. ipython::
-
-   In [8]: out_ds = in_ds.xsimlab.run(
-      ...:     model=model,
-      ...:     encoding={'pt__position': {'fill_value': -10.0}}
-      ...: )
-      ...:
-
-   In [9]: out_ds.pt__position
+:func:`~xarray.Dataset.xsimlab.run`.
 
 .. warning::
 
    Zarr uses ``0`` as the default fill value for numeric value types. This may
    badly affect the results, as array elements with the fill value are replaced
-   by NA in the output xarray Dataset. For variables which accept ``0`` as valid
-   values, it is recommended to explicitly provide an alternative ``fill_value``
-   encoding.
+   by NA in the output xarray Dataset. For variables which accept ``0`` as a
+   possible (non-missing) value, it is recommended to explicitly provide an
+   alternative ``fill_value`` encoding.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,10 +6,20 @@ Release Notes
 v0.5.0 (Unreleased)
 -------------------
 
+Breaking changes
+----------------
+
+- Fill values are now masked (NA) when when loading the simulation output store
+  as a xarray Dataset (:issue:`148`). As Zarr sets the fill value ``0`` by default
+  for numeric data types, it is recommended to explicitly define the fill value in
+  model variable encodings if ``0`` is expected to be a valid data value.
+
 Bug fixes
 ~~~~~~~~~
 
 - Fix saving output variables with dtype=object (:issue:`145`).
+- Fix issues when saving output datasets to disk that were caused by the
+  ``_FillValue`` attribute (:issue:`148`).
 
 v0.4.1 (17 April 2020)
 ----------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,7 +7,7 @@ v0.5.0 (Unreleased)
 -------------------
 
 Breaking changes
-----------------
+~~~~~~~~~~~~~~~~
 
 - Fill values are now masked (NA) when when loading the simulation output store
   as a xarray Dataset (:issue:`148`). As Zarr sets the fill value ``0`` by default

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,8 +12,10 @@ Breaking changes
 - Fill values are now masked (NA) when when loading the simulation output store
   as a xarray Dataset (:issue:`148`). Note that Zarr sets the fill value to
   ``0`` by default for numeric data types, so it is highly recommended to
-  explicitly define the fill value in model variable encodings if ``0`` is
-  expected to be a valid (non-missing) data value.
+  explicitly define another fill value in model variable encodings if ``0`` is
+  expected to be a valid (non-missing) data value, or alternatively use
+  ``mask_and_scale=False`` in the ``decoding`` options passed to
+  :func:`xarray.Dataset.simlab.run`.
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,9 +10,10 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 - Fill values are now masked (NA) when when loading the simulation output store
-  as a xarray Dataset (:issue:`148`). As Zarr sets the fill value ``0`` by default
-  for numeric data types, it is recommended to explicitly define the fill value in
-  model variable encodings if ``0`` is expected to be a valid data value.
+  as a xarray Dataset (:issue:`148`). Note that Zarr sets the fill value to
+  ``0`` by default for numeric data types, so it is highly recommended to
+  explicitly define the fill value in model variable encodings if ``0`` is
+  expected to be a valid (non-missing) data value.
 
 Bug fixes
 ~~~~~~~~~

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -376,6 +376,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
         batch_dim=None,
         store=None,
         encoding=None,
+        decoding=None,
         check_dims=CheckDimsOption.STRICT,
         validate=ValidateOption.INPUTS,
         hooks=None,
@@ -419,6 +420,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
             model,
             zobject=store,
             encoding=encoding,
+            decoding=decoding,
             batch_dim=batch_dim,
             lock=lock,
         )

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -213,10 +213,14 @@ class ZarrSimulationStore:
         zkwargs.update(var_info["encoding"])
 
         try:
+            # TODO: race condition? use lock?
             zdataset = self.zgroup.create_dataset(name, **zkwargs)
-        except ValueError:
+        except ValueError as e:
             # return early if already existing dataset (batches of simulations)
-            return
+            if name in self.zgroup.keys():
+                return
+            else:
+                raise e
 
         # add dimension labels and variable attributes as metadata
         dim_labels = None

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -347,8 +347,6 @@ class ZarrSimulationStore:
             group=self.zgroup.path,
             chunks=chunks,
             consolidated=self.consolidated,
-            # disable mask (not nice with zarr default fill_value=0)
-            mask_and_scale=False,
         )
 
         if self.in_memory:

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -355,9 +355,9 @@ class ZarrSimulationStore:
         open_kwargs = self.decoding.copy()
         open_kwargs.update(
             {
-                'chunks': chunks,
-                'group': self.zgroup.path,
-                'consolidated': self.consolidated
+                "chunks": chunks,
+                "group": self.zgroup.path,
+                "consolidated": self.consolidated,
             }
         )
 

--- a/xsimlab/tests/fixture_model.py
+++ b/xsimlab/tests/fixture_model.py
@@ -12,7 +12,7 @@ from xsimlab.xr_accessor import SimlabAccessor
 
 @xs.process
 class Profile:
-    u = xs.variable(dims="x", description="quantity u", intent="inout")
+    u = xs.variable(dims="x", description="quantity u", intent="inout", encoding={"fill_value": np.nan})
     u_diffs = xs.group("diff")
     u_opp = xs.on_demand(dims="x")
 
@@ -43,7 +43,7 @@ class InitProfile:
     u = xs.foreign(Profile, "u", intent="out")
 
     def initialize(self):
-        self.x = np.arange(self.n_points)
+        self.x = np.arange(self.n_points).astype('double')
 
         self.u = np.zeros(self.n_points)
         self.u[0] = 1.0
@@ -58,7 +58,7 @@ class Roll:
         attrs={"units": "unitless"},
     )
     u = xs.foreign(Profile, "u")
-    u_diff = xs.variable(dims="x", groups="diff", intent="out")
+    u_diff = xs.variable(dims="x", groups="diff", intent="out", encoding={"fill_value": np.nan})
 
     def run_step(self):
         self.u_diff = np.roll(self.u, self.shift) - self.u
@@ -69,21 +69,21 @@ class Add:
     offset = xs.variable(
         description=("offset * dt added every time step " "to profile u")
     )
-    u_diff = xs.variable(groups="diff", intent="out")
+    u_diff = xs.variable(groups="diff", intent="out", encoding={"fill_value": np.nan})
 
     @xs.runtime(args="step_delta")
     def run_step(self, dt):
-        self.u_diff = self.offset * dt
+        self.u_diff = self.offset * dt * 1.0
 
 
 @xs.process
 class AddOnDemand:
     offset = xs.variable(dims=[(), "x"], description="offset added to profile u")
-    u_diff = xs.on_demand(dims=[(), "x"], groups="diff")
+    u_diff = xs.on_demand(dims=[(), "x"], groups="diff", encoding={"fill_value": np.nan})
 
     @u_diff.compute
     def _compute_u_diff(self):
-        return self.offset
+        return self.offset * 1.0
 
 
 @pytest.fixture

--- a/xsimlab/tests/fixture_model.py
+++ b/xsimlab/tests/fixture_model.py
@@ -12,7 +12,12 @@ from xsimlab.xr_accessor import SimlabAccessor
 
 @xs.process
 class Profile:
-    u = xs.variable(dims="x", description="quantity u", intent="inout", encoding={"fill_value": np.nan})
+    u = xs.variable(
+        dims="x",
+        description="quantity u",
+        intent="inout",
+        encoding={"fill_value": np.nan},
+    )
     u_diffs = xs.group("diff")
     u_opp = xs.on_demand(dims="x")
 
@@ -43,7 +48,7 @@ class InitProfile:
     u = xs.foreign(Profile, "u", intent="out")
 
     def initialize(self):
-        self.x = np.arange(self.n_points).astype('double')
+        self.x = np.arange(self.n_points).astype("double")
 
         self.u = np.zeros(self.n_points)
         self.u[0] = 1.0
@@ -58,7 +63,9 @@ class Roll:
         attrs={"units": "unitless"},
     )
     u = xs.foreign(Profile, "u")
-    u_diff = xs.variable(dims="x", groups="diff", intent="out", encoding={"fill_value": np.nan})
+    u_diff = xs.variable(
+        dims="x", groups="diff", intent="out", encoding={"fill_value": np.nan}
+    )
 
     def run_step(self):
         self.u_diff = np.roll(self.u, self.shift) - self.u
@@ -79,7 +86,9 @@ class Add:
 @xs.process
 class AddOnDemand:
     offset = xs.variable(dims=[(), "x"], description="offset added to profile u")
-    u_diff = xs.on_demand(dims=[(), "x"], groups="diff", encoding={"fill_value": np.nan})
+    u_diff = xs.on_demand(
+        dims=[(), "x"], groups="diff", encoding={"fill_value": np.nan}
+    )
 
     @u_diff.compute
     def _compute_u_diff(self):

--- a/xsimlab/tests/test_drivers.py
+++ b/xsimlab/tests/test_drivers.py
@@ -97,10 +97,6 @@ class TestXarraySimulationDriver:
         xarray_driver.run_model()
         out_ds_actual = xarray_driver.get_results()
 
-        # skip attributes added by xr.open_zarr from check
-        for xr_var in out_ds_actual.variables.values():
-            xr_var.attrs.pop("_FillValue", None)
-
         assert out_ds_actual is not out_dataset
         xr.testing.assert_identical(out_ds_actual.load(), out_dataset)
 

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -677,6 +677,7 @@ class SimlabAccessor:
         validate="inputs",
         store=None,
         encoding=None,
+        decoding=None,
         hooks=None,
         parallel=False,
         scheduler=None,
@@ -730,6 +731,9 @@ class SimlabAccessor:
             model variables (see :func:`~xsimlab.variable` for a full list of
             of options available). Additionally, 'chunks' and 'synchronizer'
             options are supported here.
+        decoding : dict, optional
+            Options passed as keyword arguments to :func:`xarray.open_zarr` to load
+            the simulation outputs from the zarr store as a new xarray dataset.
         hooks : list, optional
             One or more runtime hooks, i.e., functions decorated with
             :func:`~xsimlab.runtime_hook` or instances of
@@ -754,7 +758,7 @@ class SimlabAccessor:
         Returns
         -------
         output : Dataset
-            Another Dataset with both model inputs and outputs. The data is lazily
+            Another Dataset with both model inputs and outputs. The data is (lazily)
             loaded from the zarr store used to save inputs and outputs.
 
         Notes
@@ -806,6 +810,7 @@ class SimlabAccessor:
             batch_dim=batch_dim,
             store=store,
             encoding=encoding,
+            decoding=decoding,
             check_dims=check_dims,
             validate=validate,
             hooks=hooks,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #133
 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

This leaves `mask_and_scale` to its default value (`True`) when using `xarray.open_zarr()` to load back the dataset at the end of the simulation. For convenience, a new `decoding` parameter has been added to `xarray.Dataset.xsimlab.run()` to pass keyword arguments to `xarray.open_zarr()`.