### PR TITLE
Ensure process subclasses are process-decorated

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,8 @@ Bug fixes
 - Fix saving output variables with dtype=object (:issue:`145`).
 - Fix issues when saving output datasets to disk that were caused by the
   ``_FillValue`` attribute (:issue:`148`).
+- Ensure that classes given in a Model are all process-decorated, even those
+  which inherit from process-decorated classes (:issue:`149`).
 
 v0.4.1 (17 April 2020)
 ----------------------

--- a/xsimlab/tests/test_process.py
+++ b/xsimlab/tests/test_process.py
@@ -36,13 +36,22 @@ def test_get_process_raise():
     class NotAProcess:
         pass
 
-    with pytest.raises(NotAProcessClassError) as excinfo:
+    with pytest.raises(
+        NotAProcessClassError, match=".*is not a process-decorated class."
+    ):
         get_process_cls(NotAProcess)
-    assert "is not a process-decorated class" in str(excinfo.value)
 
-    with pytest.raises(NotAProcessClassError) as excinfo:
-        get_process_obj(NotAProcess)
-    assert "is not a process-decorated class" in str(excinfo.value)
+    @xs.process
+    class A:
+        pass
+
+    class B(A):
+        pass
+
+    with pytest.raises(
+        NotAProcessClassError, match=".*inherits.*not itself process-decorated.*"
+    ):
+        get_process_cls(B)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #138
 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
