### PR TITLE
Add optional cache for on-demand variables

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -25,6 +25,8 @@ Enhancements
 - Added ``%create_setup`` IPython (Jupyter) magic command to auto-generate code
   cells with a new simulation setup from a given model (:issue:`152`). The
   command is available after executing ``%load_ext xsimlab.ipython``.
+- Added an optional cache for on-demand variables (:issue:`156`). The ``@compute``
+  decorator now has a ``cache`` option (deactivated by default).
 
 Bug fixes
 ~~~~~~~~~

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -494,6 +494,8 @@ class Model(AttrMapping):
         self._index_vars = builder.get_variables(var_type=VarType.INDEX)
         self._index_vars_dict = None
 
+        self._od_vars = builder.get_variables(var_type=VarType.ON_DEMAND)
+
         builder.ensure_no_intent_conflict()
 
         self._input_vars = builder.get_input_variables()
@@ -787,6 +789,12 @@ class Model(AttrMapping):
         for p_obj in self._processes.values():
             p_obj.__xsimlab_state__ = self._state
 
+    def _clear_od_cache(self):
+        """Clear cached values of on-demand variables."""
+
+        for key in self._od_vars:
+            self._state.pop(key, None)
+
     def execute(
         self,
         stage,
@@ -855,6 +863,8 @@ class Model(AttrMapping):
 
         stage = SimulationStage(stage)
         execute_args = (stage, runtime_context, hooks, validate)
+
+        self._clear_od_cache()
 
         self._call_hooks(hooks, runtime_context, stage, "model", "pre")
 

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -873,14 +873,14 @@ class Model(AttrMapping):
             out_states = dsk_get(dsk, "_gather", scheduler=scheduler)
 
             # TODO: without this -> flaky tests (don't know why)
-            # state is not well updated -> error when writing output vars in store
+            # state is not properly updated -> error when writing output vars in store
             if isinstance(scheduler, Client):
                 time.sleep(0.001)
 
             self._merge_and_update_state(out_states)
 
         else:
-            for p_name, p_obj in self._processes.items():
+            for p_obj in self._processes.values():
                 self._execute_process(p_obj, *execute_args)
 
         self._call_hooks(hooks, runtime_context, stage, "model", "post")

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -331,6 +331,7 @@ def runtime(meth=None, args=None):
         - ``batch`` : current simulation number in the batch
         - ``sim_start`` : simulation start (date)time
         - ``sim_end`` : simulation end (date)time
+        - ``nsteps``: total number of simulation steps
         - ``step`` : current step number
         - ``step_start`` : current step start (date)time
         - ``step_end``: current step end (date)time

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -119,7 +119,7 @@ def processes_with_state():
         model,
         state,
         state_keys={"some_var": ("some_process", "some_var")},
-        od_keys={"some_od_var": ("some_process", "some_od_var")}
+        od_keys={"some_od_var": ("some_process", "some_od_var")},
     )
     another_process = _init_process(
         AnotherProcess,

--- a/xsimlab/tests/fixture_process.py
+++ b/xsimlab/tests/fixture_process.py
@@ -119,6 +119,7 @@ def processes_with_state():
         model,
         state,
         state_keys={"some_var": ("some_process", "some_var")},
+        od_keys={"some_od_var": ("some_process", "some_od_var")}
     )
     another_process = _init_process(
         AnotherProcess,
@@ -146,6 +147,7 @@ def processes_with_state():
             "group_var": [("some_process", "some_var")],
         },
         od_keys={
+            "od_var": ("example_process", "od_var"),
             "in_foreign_od_var": ("some_process", "some_od_var"),
             "group_var": [("some_process", "some_od_var")],
         },

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -28,6 +28,7 @@ def compute(self, method=None, *, cache=False):
     value for that variable.
 
     """
+
     def attach_to_metadata(method):
         self.metadata["compute_method"] = method
         self.metadata["compute_cache"] = cache

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -23,14 +23,21 @@ class VarIntent(Enum):
     INOUT = "inout"
 
 
-def compute(self, method):
+def compute(self, method=None, *, cache=False):
     """A decorator that, when applied to an on-demand variable, returns a
     value for that variable.
 
     """
-    self.metadata["compute"] = method
+    def attach_to_metadata(method):
+        self.metadata["compute_method"] = method
+        self.metadata["compute_cache"] = cache
 
-    return method
+        return method
+
+    if method is None:
+        return attach_to_metadata
+    else:
+        return attach_to_metadata(method)
 
 
 # monkey patch, waiting for cleaner solution:

--- a/xsimlab/variable.py
+++ b/xsimlab/variable.py
@@ -291,13 +291,8 @@ def on_demand(
     Like other variables, such variable should be declared in a
     process class. Additionally, it requires its own method to compute
     its value, which must be defined in the same class and decorated
-    (e.g., using `@myvar.compute` if the name of the variable is
-    `myvar`).
-
-    An on-demand variable is always an output variable (i.e., intent='out').
-
-    Its computation usually involves other variables, although this is
-    not required.
+    (e.g., using ``@myvar.compute`` if the name of the variable is
+    ``myvar``).
 
     These variables may be useful, e.g., for model diagnostics.
 
@@ -324,6 +319,17 @@ def on_demand(
         include 'dtype', 'compressor', 'fill_value', 'order', 'filters'
         and 'object_codec'. See :func:`zarr.creation.create` for details
         about these options. Other keys are ignored.
+
+    Notes
+    -----
+    An on-demand variable is always an output variable (i.e., intent='out').
+
+    Its computation usually involves other variables, although this is
+    not required.
+
+    It is possible to cache its value at each simulation stage, by applying
+    the compute decorator like this: ``@myvar.compute(cache=True)``. This is
+    useful if the variable is meant to be accessed many times in other processes.
 
     See Also
     --------


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #132
 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
