### PR TITLE
Runtime signals

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -189,3 +189,4 @@ Model runtime monitoring
    monitoring.ProgressBar
    runtime_hook
    RuntimeHook
+   RuntimeSignal

--- a/doc/framework.rst
+++ b/doc/framework.rst
@@ -224,18 +224,26 @@ A model run is divided into four successive stages:
 3. finalize step
 4. finalization
 
-During a simulation, stages 1 and 4 are run only once while stages 2
-and 3 are repeated for a given number of (time) steps. Stage 4 is run even if
-an exception is raised during stage 1, 2 or 3.
+During a simulation, stages 1 and 4 are run only once while stages 2 and 3 are
+repeated for a given number of (time) steps. Stage 4 is always run even when an
+exception is raised during stage 1, 2 or 3.
 
-Each process-ified class may provide its own computation instructions
-by implementing specific methods named ``.initialize()``,
-``.run_step()``, ``.finalize_step()`` and ``.finalize()`` for each
-stage above, respectively. Note that this is entirely optional. For
-example, time-independent processes (e.g., for setting model grids)
-usually implement stage 1 only. In a few cases, the role of a process
-may even consist of just declaring some variables that are used
-elsewhere.
+Each :func:`~xsimlab.process` decorated class may provide its own computation
+instructions by implementing specific "runtime" methods named ``.initialize()``,
+``.run_step()``, ``.finalize_step()`` and ``.finalize()`` for each stage above,
+respectively. Note that this is entirely optional. For example, time-independent
+processes (e.g., for setting model grids) usually implement stage 1 only. In a
+few cases, the role of a process may even consist of just declaring some
+variables that are used elsewhere.
+
+Runtime methods may be decorated by :func:`~xsimlab.runtime`. This is useful if
+one needs to access the value of some runtime-specific variables like the
+current step, time step duration, etc. from within those methods. Runtime
+methods may also return a :func:`~xsimlab.RuntimeSignal` to control the
+workflow, e.g., break the execution of the current stage.
+
+It is also possible to monitor and/or control simulations independently of any
+model, using runtime hooks. See Section :ref:`monitor`.
 
 Get / set variable values inside a process
 ------------------------------------------

--- a/doc/run_model.rst
+++ b/doc/run_model.rst
@@ -106,20 +106,21 @@ IPython (Jupyter) magic commands
 
 Writing a new setup from scratch may be tedious, especially for big models with
 a lot of input variables. If you are using IPython (Jupyter), xarray-simlab
-provides convenient commands that can be activated with:
+provides helper commands that are available after loading the
+``xsimlab.ipython`` extension, i.e.,
 
 .. ipython:: python
 
    %load_ext xsimlab.ipython
 
 The ``%create_setup`` magic command auto-generates the
-:func:`~xsimlab.create_setup` code cell above from a given model:
+:func:`~xsimlab.create_setup` code cell above from a given model, e.g.,
 
 .. ipython:: python
 
-   %create_setup advect_model --default --comment
+   %create_setup advect_model --default --verbose
 
-The ``--default`` and ``--comment`` options respectively add default values found
+The ``--default`` and ``--verbose`` options respectively add default values found
 for input variables in the model and input variable description as line comments.
 
 Full command help:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,6 +30,8 @@ Enhancements
 - Added :func:`~xsimlab.group_dict` variable (:issue:`159`).
 - Added :func:`~xsimlab.global_ref` variable for model-wise implicit linking of
   variables in separate processes, based on global names (:issue:`160`).
+- Added :class:`~xsimlab.RuntimeSignal` for controlling simulation workflow from
+  process runtime methods and/or runtime hook functions (:issue:`161`).
 
 Bug fixes
 ~~~~~~~~~

--- a/xsimlab/__init__.py
+++ b/xsimlab/__init__.py
@@ -11,6 +11,7 @@ from .process import (
     process,
     process_info,
     runtime,
+    RuntimeSignal,
     variable_info,
 )
 from .variable import (

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -353,8 +353,8 @@ def _run(
 
         store.write_output_vars(batch, -1, model=model)
         store.write_index_vars(model=model)
-    except Exception as error:
-        raise error
+    except Exception:
+        raise
     finally:
         model.execute("finalize", rt_context, **execute_kwargs)
 

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -348,12 +348,15 @@ def _run(
             model.update_state(in_vars, validate=validate_inputs, ignore_static=False)
             signal = model.execute("run_step", rt_context, **execute_kwargs)
 
-            if signal == RuntimeSignal.CONTINUE:
-                continue
-            elif signal == RuntimeSignal.BREAK:
+            if signal == RuntimeSignal.BREAK:
                 break
 
             store.write_output_vars(batch, step, model=model)
+
+            # after writing output variables so that index positions
+            # are properly updated in store.
+            if signal == RuntimeSignal.CONTINUE:
+                continue
 
             signal = model.execute("finalize_step", rt_context, **execute_kwargs)
 

--- a/xsimlab/hook.py
+++ b/xsimlab/hook.py
@@ -1,10 +1,16 @@
 import inspect
+from enum import Enum
 from typing import Callable, Dict, Iterable, List, Union
 
 from .process import SimulationStage
 
 
-__all__ = ("runtime_hook", "RuntimeHook")
+class RuntimeSignal(Enum):
+    NONE = 0
+    SKIP = 1
+    CONTINUE = 2
+    BREAK = 3
+    STOP = 4
 
 
 def runtime_hook(stage, level="model", trigger="post"):

--- a/xsimlab/hook.py
+++ b/xsimlab/hook.py
@@ -10,7 +10,8 @@ def runtime_hook(stage, level="model", trigger="post"):
     at one or more specific times during a simulation.
 
     The decorated function / method must have the following signature:
-    ``func(model, context, state)`` or ``meth(self, model, context, state)``.
+    ``func(model, context, state)`` or ``meth(self, model, context, state)``. It
+    may return a :class:`RuntimeSignal` (optional).
 
     Parameters
     ----------

--- a/xsimlab/hook.py
+++ b/xsimlab/hook.py
@@ -5,14 +5,6 @@ from typing import Callable, Dict, Iterable, List, Union
 from .process import SimulationStage
 
 
-class RuntimeSignal(Enum):
-    NONE = 0
-    SKIP = 1
-    CONTINUE = 2
-    BREAK = 3
-    STOP = 4
-
-
 def runtime_hook(stage, level="model", trigger="post"):
     """Decorator that allows to call a function or a method
     at one or more specific times during a simulation.

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -839,7 +839,9 @@ class Model(AttrMapping):
         if signal_pre.value > 0:
             return p_name, ({}, signal_pre)
 
-        state_out, signal_out = executor.execute(p_obj, stage, runtime_context, state=state)
+        state_out, signal_out = executor.execute(
+            p_obj, stage, runtime_context, state=state
+        )
 
         signal_post = self._call_hooks(hooks, runtime_context, stage, "process", "post")
         if signal_post.value > signal_out.value:
@@ -855,6 +857,7 @@ class Model(AttrMapping):
         be passed to a Dask scheduler.
 
         """
+
         def exec_process(p_obj, model_state, exec_outputs):
             # update model state with output states from all dependent processes
             # gather signals returned by all dependent processes and sort them by highest piority
@@ -882,7 +885,10 @@ class Model(AttrMapping):
             dsk[p_name] = (exec_process, self._processes[p_name], self._state, p_deps)
 
         # add a node to gather output state from all executed processes
-        dsk["_gather"] = (lambda exec_outputs: dict(exec_outputs), list(self._processes))
+        dsk["_gather"] = (
+            lambda exec_outputs: dict(exec_outputs),
+            list(self._processes),
+        )
 
         return dsk
 

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -961,7 +961,8 @@ class Model(AttrMapping):
         -------
         signal : :class:`RuntimeSignal`
             Signal with hightest priority among all signals returned by hook
-            functions, or ``RuntimeSignal.NONE`.
+            functions and/or process runtime methods, if any. Otherwise,
+            returns ``RuntimeSignal.NONE``.
 
         Notes
         -----

--- a/xsimlab/model.py
+++ b/xsimlab/model.py
@@ -860,7 +860,7 @@ class Model(AttrMapping):
 
         def exec_process(p_obj, model_state, exec_outputs):
             # update model state with output states from all dependent processes
-            # gather signals returned by all dependent processes and sort them by highest piority
+            # gather signals returned by all dependent processes and sort them by highest priority
             state = {}
             signal = RuntimeSignal.NONE
 
@@ -884,7 +884,7 @@ class Model(AttrMapping):
         for p_name, p_deps in self._dep_processes.items():
             dsk[p_name] = (exec_process, self._processes[p_name], self._state, p_deps)
 
-        # add a node to gather output state from all executed processes
+        # add a node to gather output signals and state from all executed processes
         dsk["_gather"] = (
             lambda exec_outputs: dict(exec_outputs),
             list(self._processes),

--- a/xsimlab/monitoring.py
+++ b/xsimlab/monitoring.py
@@ -78,7 +78,7 @@ class ProgressBar(RuntimeHook):
         self.pbar_model = self.tqdm(**self.tqdm_kwargs)
 
     @runtime_hook("initialize", trigger="post")
-    def update_init(self, mode, context, state):
+    def update_init(self, model, context, state):
         self.pbar_model.update(1)
 
     @runtime_hook("run_step", trigger="post")

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -327,6 +327,7 @@ class _RuntimeMethodExecutor:
     - returns a valid runtime signal.
 
     """
+
     def __init__(self, meth, args=None):
         self.meth = meth
 

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -312,8 +312,13 @@ class _RuntimeMethodExecutor:
     """Used to execute a process 'runtime' method in the context of a
     simulation.
 
-    """
+    This is a thin wrapper around a process class runtime method, which:
 
+    - maps method argument(s) to their corresponding simulation runtime variable.
+    - optionally overrides the process object's state with an input state (i.e., when
+      executed as part of a Dask graph).
+
+    """
     def __init__(self, meth, args=None):
         self.meth = meth
 
@@ -454,6 +459,11 @@ class _ProcessExecutor:
         return [k.value for k in self.runtime_executors]
 
     def execute(self, obj, stage, runtime_context, state=None):
+        """Maybe execute the given simulation stage (if implemented).
+
+        Returns a state dictionary with only the 'out'/'inout' variables.
+
+        """
         executor = self.runtime_executors.get(stage)
 
         if executor is None:

--- a/xsimlab/process.py
+++ b/xsimlab/process.py
@@ -309,10 +309,53 @@ def _make_property_group_dict(var):
 
 
 class RuntimeSignal(Enum):
+    """Signal controlling simulation runtime.
+
+    Such signal may be returned either by runtime methods of :func:`process`
+    decorated classes or by :func:`runtime_hook` decorated functions or methods.
+
+    All signals listed below are ordered from the lowest to the highest
+    priority. If multiple signals are emitted at the same time during a
+    simulation, the one with the highest priority prevails.
+
+    One signal may affect the simulation workflow in different ways, depending on
+    whether it is returned during the execution of a simulation stage (process-level)
+    or just before/after a stage (model-level).
+
+    Attributes
+    ----------
+    NONE : int
+        Do nothing (blank signal). Used by default when a process
+        runtime method or a hook function doesn't explicitly return a value.
+        Priority = 0.
+    SKIP : int
+        If returned by a pre-hook function, skip the current process
+        (process-level) or the current simulation stage (model-level).
+        Otherwise do nothing.
+        Priority = 1.
+    CONTINUE : int
+        Skip the current process or current simulation stage (pre-hook).
+        When returned by a model-level hook function in a looped
+        simulation stage (e.g., ``run_step``), also skip all remaining
+        simulation stages (e.g., ``finalize_step``) at the current step and
+        continues the simulation at the next step.
+        Priority = 2.
+    BREAK : int
+        Skip the current process or current simulation stage (pre-hook).
+        Also skip all remaining processes in a simulation stage (process-level)
+        or all remaining steps in looped simulation stages (model-level).
+        Priority = 3.
+
+    """
+
     NONE = 0
+    """Do nothing (blank signal)."""
     SKIP = 1
+    """Skip the current process or simulation stage."""
     CONTINUE = 2
+    """Skip all the remaining stages of the current step."""
     BREAK = 3
+    """Skip all remaining processes or steps."""
 
 
 class _RuntimeMethodExecutor:

--- a/xsimlab/tests/test_process.py
+++ b/xsimlab/tests/test_process.py
@@ -303,11 +303,15 @@ def test_process_executor():
     executor = m.p.__xsimlab_executor__
     state = {("p", "in_var"): 1}
 
-    state_out, signal_out = executor.execute(m.p, SimulationStage.RUN_STEP, {}, state=state)
+    state_out, signal_out = executor.execute(
+        m.p, SimulationStage.RUN_STEP, {}, state=state
+    )
     assert state_out == {("p", "out_var"): 2}
     assert signal_out == xs.RuntimeSignal.BREAK
 
-    state_out, signal_out = executor.execute(m.p, SimulationStage.INITIALIZE, {}, state=state)
+    state_out, signal_out = executor.execute(
+        m.p, SimulationStage.INITIALIZE, {}, state=state
+    )
     assert state_out == {}
     assert signal_out == xs.RuntimeSignal.NONE
 

--- a/xsimlab/tests/test_process.py
+++ b/xsimlab/tests/test_process.py
@@ -293,6 +293,7 @@ def test_process_executor():
 
         def run_step(self):
             self.out_var = self.in_var * 2
+            return xs.RuntimeSignal.BREAK
 
         @od_var.compute
         def _dummy(self):
@@ -302,11 +303,13 @@ def test_process_executor():
     executor = m.p.__xsimlab_executor__
     state = {("p", "in_var"): 1}
 
-    expected = {("p", "out_var"): 2}
-    actual = executor.execute(m.p, SimulationStage.RUN_STEP, {}, state=state)
-    assert actual == expected
+    state_out, signal_out = executor.execute(m.p, SimulationStage.RUN_STEP, {}, state=state)
+    assert state_out == {("p", "out_var"): 2}
+    assert signal_out == xs.RuntimeSignal.BREAK
 
-    assert executor.execute(m.p, SimulationStage.INITIALIZE, {}, state=state) == {}
+    state_out, signal_out = executor.execute(m.p, SimulationStage.INITIALIZE, {}, state=state)
+    assert state_out == {}
+    assert signal_out == xs.RuntimeSignal.NONE
 
 
 def test_process_executor_raise():

--- a/xsimlab/tests/test_signals.py
+++ b/xsimlab/tests/test_signals.py
@@ -1,0 +1,109 @@
+import numpy as np
+import pytest
+
+import xsimlab as xs
+from xsimlab.process import SimulationStage
+
+
+@pytest.mark.parametrize(
+    "trigger,signal,expected",
+    [
+        ("pre", xs.RuntimeSignal.SKIP, [1.0, 2.0, 4.0, 5.0]),
+        ("post", xs.RuntimeSignal.SKIP, [1.0, 3.0, 5.0, 6.0]),
+        ("pre", xs.RuntimeSignal.CONTINUE, [1.0, 2.0, 3.0, 4.0]),
+        ("post", xs.RuntimeSignal.CONTINUE, [1.0, 3.0, 4.0, 5.0]),
+        ("pre", xs.RuntimeSignal.BREAK, [1.0, 2.0, np.nan, np.nan]),
+        ("post", xs.RuntimeSignal.BREAK, [1.0, 3.0, np.nan, np.nan]),
+    ]
+)
+def test_signal_model_level(trigger, signal, expected):
+    @xs.process
+    class Foo:
+        v = xs.variable(intent="out")
+        vv = xs.variable(intent="out")
+
+        def initialize(self):
+            self.v = 0.0
+            self.vv = 10.0
+
+        def run_step(self):
+            self.v += 1.0
+
+        def finalize_step(self):
+            self.v += 1.0
+
+    @xs.runtime_hook("run_step", level="model", trigger=trigger)
+    def hook_func(model, context, state):
+        if context["step"] == 1:
+            return signal
+
+    model = xs.Model({'foo': Foo})
+    ds_in = xs.create_setup(
+        model=model,
+        clocks={'clock': range(4)},
+        output_vars={"foo__v": "clock", "foo__vv": None},
+    )
+    ds_out = ds_in.xsimlab.run(model=model, hooks=[hook_func])
+
+    np.testing.assert_equal(ds_out.foo__v.values, expected)
+
+    # ensure that clock-independent output variables are properly
+    # saved even when the simulation stops early
+    assert ds_out.foo__vv == 10.0
+
+
+@pytest.fixture(params=[True, False])
+def parallel(request):
+    return request.param
+
+
+@pytest.mark.parametrize(
+    "step,trigger,signal,break_bar,expected_v1,expected_v2",
+    [
+        # Both Foo.run_step and Bar.run_step are run
+        (0, "pre", xs.RuntimeSignal.SKIP, False, 1, 2),
+        # None of Foo.run_step and Bar.run_step are run
+        (1, "pre", xs.RuntimeSignal.SKIP, False, 0, 0),
+        # BREAK signal returned in Bar.run_step prevails
+        (1, "post", xs.RuntimeSignal.SKIP, True, 0, 2),
+        # BREAK signal returned by Bar.run_step only
+        (0, "post", xs.RuntimeSignal.BREAK, True, 0, 2)
+    ]
+)
+def test_signal_process_level(step, trigger, signal, break_bar, expected_v1, expected_v2, parallel):
+    @xs.process
+    class Foo:
+        v1 = xs.variable(intent="out")
+        v2 = xs.variable()
+
+        def initialize(self):
+            self.v1 = 0
+
+        def run_step(self):
+            self.v1 = 1
+
+    @xs.process
+    class Bar:
+        v2 = xs.foreign(Foo, "v2", intent="out")
+
+        def initialize(self):
+            self.v2 = 0
+
+        def run_step(self):
+            self.v2 = 2
+
+            if break_bar:
+                return xs.RuntimeSignal.BREAK
+
+    def hook_func(model, context, state):
+        if context["step"] == 1:
+            return signal
+
+    hook_dict = {SimulationStage.RUN_STEP: {"process": {trigger: [hook_func]}}}
+
+    model = xs.Model({"foo": Foo, "bar": Bar})
+    model.execute("initialize", {})
+    model.execute("run_step", {"step": step}, hooks=hook_dict, parallel=parallel)
+
+    assert model.state[("foo", "v1")] == expected_v1
+    assert model.state[("foo", "v2")] == expected_v2

--- a/xsimlab/tests/test_signals.py
+++ b/xsimlab/tests/test_signals.py
@@ -14,7 +14,7 @@ from xsimlab.process import SimulationStage
         ("post", xs.RuntimeSignal.CONTINUE, [1.0, 3.0, 4.0, 5.0]),
         ("pre", xs.RuntimeSignal.BREAK, [1.0, 2.0, np.nan, np.nan]),
         ("post", xs.RuntimeSignal.BREAK, [1.0, 3.0, np.nan, np.nan]),
-    ]
+    ],
 )
 def test_signal_model_level(trigger, signal, expected):
     @xs.process
@@ -37,10 +37,10 @@ def test_signal_model_level(trigger, signal, expected):
         if context["step"] == 1:
             return signal
 
-    model = xs.Model({'foo': Foo})
+    model = xs.Model({"foo": Foo})
     ds_in = xs.create_setup(
         model=model,
-        clocks={'clock': range(4)},
+        clocks={"clock": range(4)},
         output_vars={"foo__v": "clock", "foo__vv": None},
     )
     ds_out = ds_in.xsimlab.run(model=model, hooks=[hook_func])
@@ -67,10 +67,12 @@ def parallel(request):
         # BREAK signal returned in Bar.run_step prevails
         (1, "post", xs.RuntimeSignal.SKIP, True, 0, 2),
         # BREAK signal returned by Bar.run_step only
-        (0, "post", xs.RuntimeSignal.BREAK, True, 0, 2)
-    ]
+        (0, "post", xs.RuntimeSignal.BREAK, True, 0, 2),
+    ],
 )
-def test_signal_process_level(step, trigger, signal, break_bar, expected_v1, expected_v2, parallel):
+def test_signal_process_level(
+    step, trigger, signal, break_bar, expected_v1, expected_v2, parallel
+):
     @xs.process
     class Foo:
         v1 = xs.variable(intent="out")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #152
 - [x] Tests added
 - [x] Passes `black . && flake8`
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
