### PR TITLE
added a main_clock with dimension 'mclock' to initialize context, thi…

### DIFF
--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -156,15 +156,13 @@ def _generate_runtime_datasets(dataset):
     """
     mclock_dim = dataset.xsimlab.master_clock_dim
 
-
-
     # prevent non-index coordinates be included
     mclock_coord = dataset[mclock_dim].reset_coords(drop=True)
 
     init_data_vars = {
         "_sim_start": mclock_coord[0],
         "_nsteps": dataset.xsimlab.nsteps,
-        #since we pass a dataset, we need to set the coords
+        # since we pass a dataset, we need to set the coords
         "mclock": dataset.coords[mclock_dim].data,
         "_sim_end": mclock_coord[-1],
     }

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -28,6 +28,7 @@ class RuntimeContext(Mapping[str, Any]):
         "batch",
         "sim_start",
         "sim_end",
+        "main_clock",
         "step",
         "nsteps",
         "step_start",
@@ -155,12 +156,16 @@ def _generate_runtime_datasets(dataset):
     """
     mclock_dim = dataset.xsimlab.master_clock_dim
 
+
+
     # prevent non-index coordinates be included
     mclock_coord = dataset[mclock_dim].reset_coords(drop=True)
 
     init_data_vars = {
         "_sim_start": mclock_coord[0],
         "_nsteps": dataset.xsimlab.nsteps,
+        #since we pass a dataset, we need to set the coords
+        "mclock": dataset.coords[mclock_dim].data,
         "_sim_end": mclock_coord[-1],
     }
 
@@ -327,6 +332,7 @@ def _run(
         sim_start=ds_init["_sim_start"].values,
         nsteps=ds_init["_nsteps"].values,
         sim_end=ds_init["_sim_end"].values,
+        main_clock=ds_init["mclock"],
     )
 
     in_vars = _get_input_vars(ds_init, model)


### PR DESCRIPTION
…s returns a xr.DataArray. However, I cannot set xs.variables in the initialize step: 'AttributeError: cannot set attribute'

<!-- Feel free to remove check-list items aren't relevant to your change -->


-  [x] Closes #155 
 - [ ] Tests added
 - [ ] Passes `black . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
