### PR TITLE
Master main change

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/home/joempie/miniconda3/envs/simlab-dev/bin/python"
+}

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -42,8 +42,8 @@ properties listed below. Proper use of this accessor should be like:
 
    Dataset.xsimlab.clock_coords
    Dataset.xsimlab.clock_sizes
-   Dataset.xsimlab.master_clock_dim
-   Dataset.xsimlab.master_clock_coord
+   Dataset.xsimlab.main_clock_dim
+   Dataset.xsimlab.main_clock_coord
    Dataset.xsimlab.nsteps
    Dataset.xsimlab.output_vars
    Dataset.xsimlab.output_vars_by_clock

--- a/doc/io_storage.rst
+++ b/doc/io_storage.rst
@@ -43,7 +43,7 @@ one used in Section :doc:`run_model`:
             'time': np.linspace(0., 1., 101),
             'otime': [0, 0.5, 1]
         },
-        master_clock='time',
+        main_clock='time',
         input_vars={
             'grid': {'length': 1.5, 'spacing': 0.01},
             'init': {'loc': 0.3, 'scale': 0.1},

--- a/doc/run_model.rst
+++ b/doc/run_model.rst
@@ -52,7 +52,7 @@ create a new setup in a very declarative way:
             'time': np.linspace(0., 1., 101),
             'otime': [0, 0.5, 1]
         },
-        master_clock='time',
+        main_clock='time',
         input_vars={
             'grid': {'length': 1.5, 'spacing': 0.01},
             'init': {'loc': 0.3, 'scale': 0.1},
@@ -72,7 +72,7 @@ A setup consists in:
 
 - one or more time dimensions ("clocks") and their given coordinate
   values ;
-- one of these time dimensions, defined as master clock, which will be
+- one of these time dimensions, defined as main clock, which will be
   used to define the simulation time steps (the other time dimensions
   usually serve to take snapshots during a simulation on a different
   but synchronized clock) ;
@@ -81,7 +81,7 @@ A setup consists in:
   clocks (time dimension) or just once at the end of the simulation
   (``None``).
 
-In the example above, we set ``time`` as the master clock dimension
+In the example above, we set ``time`` as the main clock dimension
 and ``otime`` as another dimension for taking snapshots of :math:`u`
 along the grid at three given times of the simulation (beginning,
 middle and end).
@@ -225,7 +225,7 @@ for the ``otime`` coordinate (which serves to take snapshots of
     clocks = {'otime': [0, 0.25, 0.5]}
     with advect_model:
         out_ds3 = (in_ds.xsimlab.update_clocks(clocks=clocks,
-                                               master_clock='time')
+                                               main_clock='time')
                         .xsimlab.run())
     @savefig run_advect_model_clock.png width=100%
     out_ds3.profile__u.plot(col='otime', figsize=(9, 3));
@@ -258,7 +258,7 @@ Time-varying input values
 -------------------------
 
 Except for static variables, all model inputs accept arrays which have a
-dimension that corresponds to the master clock. This is useful for adding
+dimension that corresponds to the main clock. This is useful for adding
 external forcing.
 
 The example below is based on the last example above, but instead of

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -156,15 +156,13 @@ def _generate_runtime_datasets(dataset):
     """
     mclock_dim = dataset.xsimlab.master_clock_dim
 
-
-
     # prevent non-index coordinates be included
     mclock_coord = dataset[mclock_dim].reset_coords(drop=True)
 
     init_data_vars = {
         "_sim_start": mclock_coord[0],
         "_nsteps": dataset.xsimlab.nsteps,
-        #since we pass a dataset, we need to set the coords
+        # since we pass a dataset, we need to set the coords
         "mclock": dataset.coords[mclock_dim].data,
         "_sim_end": mclock_coord[-1],
     }

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -111,9 +111,9 @@ def _reset_multi_indexes(dataset):
     return dataset.reset_index(dims), multi_indexes
 
 
-def _check_missing_master_clock(dataset):
-    if dataset.xsimlab.master_clock_dim is None:
-        raise ValueError("Missing master clock dimension / coordinate")
+def _check_missing_main_clock(dataset):
+    if dataset.xsimlab.main_clock_dim is None:
+        raise ValueError("Missing main clock dimension / coordinate")
 
 
 def _check_missing_inputs(dataset, model):
@@ -154,7 +154,7 @@ def _generate_runtime_datasets(dataset):
     Runtime data is added to those datasets.
 
     """
-    mclock_dim = dataset.xsimlab.master_clock_dim
+    mclock_dim = dataset.xsimlab.main_clock_dim
 
     # prevent non-index coordinates be included
     mclock_coord = dataset[mclock_dim].reset_coords(drop=True)
@@ -190,7 +190,7 @@ def _maybe_transpose(dataset, model, check_dims, batch_dim):
     """Check and maybe re-order the dimensions of model input variables in the input
     dataset.
 
-    Dimensions are re-ordered like this: (<batch dim>, <master clock dim>, *model var dims)
+    Dimensions are re-ordered like this: (<batch dim>, <main clock dim>, *model var dims)
 
     Raise an error if dimensions found in the dataset are not valid or could not
     be transposed.
@@ -210,7 +210,7 @@ def _maybe_transpose(dataset, model, check_dims, batch_dim):
 
         # all valid dimensions in the right order
         dims = [list(d) for d in model.cache[var_key]["metadata"]["dims"]]
-        dims += [[dataset.xsimlab.master_clock_dim] + d for d in dims]
+        dims += [[dataset.xsimlab.main_clock_dim] + d for d in dims]
         if batch_dim is not None:
             dims += [[batch_dim] + d for d in dims]
 
@@ -408,7 +408,7 @@ class XarraySimulationDriver(BaseSimulationDriver):
 
         self.dataset, self.multi_indexes = _reset_multi_indexes(dataset)
 
-        _check_missing_master_clock(self.dataset)
+        _check_missing_main_clock(self.dataset)
         _check_missing_inputs(self.dataset, model)
 
         self.batch_dim = batch_dim

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -28,6 +28,7 @@ class RuntimeContext(Mapping[str, Any]):
         "batch",
         "sim_start",
         "sim_end",
+        "main_clock",
         "step",
         "nsteps",
         "step_start",
@@ -155,12 +156,16 @@ def _generate_runtime_datasets(dataset):
     """
     mclock_dim = dataset.xsimlab.master_clock_dim
 
+
+
     # prevent non-index coordinates be included
     mclock_coord = dataset[mclock_dim].reset_coords(drop=True)
 
     init_data_vars = {
         "_sim_start": mclock_coord[0],
         "_nsteps": dataset.xsimlab.nsteps,
+        #since we pass a dataset, we need to set the coords
+        "mclock": dataset.coords[mclock_dim].data,
         "_sim_end": mclock_coord[-1],
     }
 
@@ -327,6 +332,7 @@ def _run(
         sim_start=ds_init["_sim_start"].values,
         nsteps=ds_init["_nsteps"].values,
         sim_end=ds_init["_sim_end"].values,
+        main_clock=ds_init["mclock"],
     )
 
     in_vars = _get_input_vars(ds_init, model)

--- a/xsimlab/drivers.py
+++ b/xsimlab/drivers.py
@@ -162,8 +162,6 @@ def _generate_runtime_datasets(dataset):
     init_data_vars = {
         "_sim_start": mclock_coord[0],
         "_nsteps": dataset.xsimlab.nsteps,
-        # since we pass a dataset, we need to set the coords
-        "mclock": dataset.coords[mclock_dim].data,
         "_sim_end": mclock_coord[-1],
     }
 
@@ -330,7 +328,6 @@ def _run(
         sim_start=ds_init["_sim_start"].values,
         nsteps=ds_init["_nsteps"].values,
         sim_end=ds_init["_sim_end"].values,
-        main_clock=ds_init["mclock"],
     )
 
     in_vars = _get_input_vars(ds_init, model)

--- a/xsimlab/ipython.py
+++ b/xsimlab/ipython.py
@@ -41,7 +41,7 @@ def format_var_comment(var, verbose=0):
         if var_dims:
             comment += f"#     dimensions: {var_dims}\n"
         if var.metadata["static"]:
-            comment += f"#     static: master clock dimension not supported\n"
+            comment += f"#     static: main clock dimension not supported\n"
 
     if verbose > 2:
         var_attrs = var.metadata.get("attrs", False)

--- a/xsimlab/stores.py
+++ b/xsimlab/stores.py
@@ -139,7 +139,7 @@ class ZarrSimulationStore:
         self.batch_dim = batch_dim
         self.batch_size = get_batch_size(dataset, batch_dim)
 
-        self.mclock_dim = dataset.xsimlab.master_clock_dim
+        self.mclock_dim = dataset.xsimlab.main_clock_dim
         self.clock_sizes = dataset.xsimlab.clock_sizes
 
         # initialize clock incrementers

--- a/xsimlab/tests/fixture_model.py
+++ b/xsimlab/tests/fixture_model.py
@@ -133,7 +133,7 @@ def simple_model_repr():
 @pytest.fixture
 def in_dataset():
     clock_key = SimlabAccessor._clock_key
-    mclock_key = SimlabAccessor._master_clock_key
+    mclock_key = SimlabAccessor._main_clock_key
     svars_key = SimlabAccessor._output_vars_key
 
     ds = xr.Dataset()

--- a/xsimlab/tests/test_drivers.py
+++ b/xsimlab/tests/test_drivers.py
@@ -86,7 +86,7 @@ def test_get_input_vars_scalar(in_dataset, model, value, is_scalar):
 class TestXarraySimulationDriver:
     def test_constructor(self, in_dataset, model):
         invalid_ds = in_dataset.drop("clock")
-        with pytest.raises(ValueError, match=r"Missing master clock.*"):
+        with pytest.raises(ValueError, match=r"Missing main clock.*"):
             XarraySimulationDriver(invalid_ds, model)
 
         invalid_ds = in_dataset.drop("init_profile__n_points")

--- a/xsimlab/tests/test_ipython.py
+++ b/xsimlab/tests/test_ipython.py
@@ -143,7 +143,7 @@ ds_in = xs.create_setup(
     input_vars={
         # v1 description
         #     dimensions: ('x',)
-        #     static: master clock dimension not supported
+        #     static: main clock dimension not supported
         'foo__v1': ,
         # v2 description
         'foo__v2': ,
@@ -164,7 +164,7 @@ ds_in = xs.create_setup(
     input_vars={
         # v1 description
         #     dimensions: ('x',)
-        #     static: master clock dimension not supported
+        #     static: main clock dimension not supported
         'foo__v1': ,
         # v2 description
         #     units: m

--- a/xsimlab/tests/test_xr_accessor.py
+++ b/xsimlab/tests/test_xr_accessor.py
@@ -113,7 +113,7 @@ def test_flatten_outputs_error():
 class TestSimlabAccessor:
 
     _clock_key = xr_accessor.SimlabAccessor._clock_key
-    _master_clock_key = xr_accessor.SimlabAccessor._master_clock_key
+    _main_clock_key = xr_accessor.SimlabAccessor._main_clock_key
     _output_vars_key = xr_accessor.SimlabAccessor._output_vars_key
 
     def test_clock_coords(self):
@@ -122,7 +122,7 @@ class TestSimlabAccessor:
                 "mclock": (
                     "mclock",
                     [0, 1, 2],
-                    {self._clock_key: 1, self._master_clock_key: 1},
+                    {self._clock_key: 1, self._main_clock_key: 1},
                 ),
                 "sclock": ("sclock", [0, 2], {self._clock_key: 1}),
                 "no_clock": ("no_clock", [3, 4]),
@@ -141,19 +141,19 @@ class TestSimlabAccessor:
 
         assert ds.xsimlab.clock_sizes == {"clock1": 3, "clock2": 2}
 
-    def test_master_clock_dim(self):
-        attrs = {self._clock_key: 1, self._master_clock_key: 1}
+    def test_main_clock_dim(self):
+        attrs = {self._clock_key: 1, self._main_clock_key: 1}
         ds = xr.Dataset(coords={"clock": ("clock", [1, 2], attrs)})
 
-        assert ds.xsimlab.master_clock_dim == "clock"
-        assert ds.xsimlab._master_clock_dim == "clock"  # cache
-        assert ds.xsimlab.master_clock_dim == "clock"  # get cached value
+        assert ds.xsimlab.main_clock_dim == "clock"
+        assert ds.xsimlab._main_clock_dim == "clock"  # cache
+        assert ds.xsimlab.main_clock_dim == "clock"  # get cached value
 
         ds = xr.Dataset()
-        assert ds.xsimlab.master_clock_dim is None
+        assert ds.xsimlab.main_clock_dim is None
 
     def test_nsteps(self):
-        attrs = {self._clock_key: 1, self._master_clock_key: 1}
+        attrs = {self._clock_key: 1, self._main_clock_key: 1}
         ds = xr.Dataset(coords={"clock": ("clock", [1, 2, 3], attrs)})
 
         assert ds.xsimlab.nsteps == 2
@@ -162,7 +162,7 @@ class TestSimlabAccessor:
         assert ds.xsimlab.nsteps == 0
 
     def test_get_output_save_steps(self):
-        attrs = {self._clock_key: 1, self._master_clock_key: 1}
+        attrs = {self._clock_key: 1, self._main_clock_key: 1}
         ds = xr.Dataset(
             coords={
                 "clock": ("clock", [0, 1, 2, 3, 4], attrs),
@@ -228,7 +228,7 @@ class TestSimlabAccessor:
             )
 
         ds = xr.Dataset()
-        with pytest.raises(KeyError, match="Master clock dimension name.*"):
+        with pytest.raises(KeyError, match="Main clock dimension name.*"):
             ds.xsimlab.update_clocks(
                 model=model,
                 clocks={"clock": [0, 1, 2]},
@@ -252,7 +252,7 @@ class TestSimlabAccessor:
 
         ds = xr.Dataset()
         ds = ds.xsimlab.update_clocks(model=model, clocks={"clock": [0, 1, 2]})
-        assert ds.xsimlab.master_clock_dim == "clock"
+        assert ds.xsimlab.main_clock_dim == "clock"
 
         ds.clock.attrs[self._output_vars_key] = "profile__u"
 
@@ -275,13 +275,13 @@ class TestSimlabAccessor:
             clocks={"clock2": [0, 0.5, 1, 1.5, 2]},
             master_clock="clock2",
         )
-        assert new_ds.xsimlab.master_clock_dim == "clock2"
+        assert new_ds.xsimlab.main_clock_dim == "clock2"
 
         new_ds = ds.xsimlab.update_clocks(model=model, clocks={"out2": [0, 2]})
-        assert new_ds.xsimlab.master_clock_dim == "clock"
+        assert new_ds.xsimlab.main_clock_dim == "clock"
 
         new_ds = ds.xsimlab.update_clocks(model=model, clocks={"clock": [0, 2, 4]})
-        assert new_ds.xsimlab.master_clock_dim == "clock"
+        assert new_ds.xsimlab.main_clock_dim == "clock"
         np.testing.assert_array_equal(new_ds.clock.values, [0, 2, 4])
 
     def test_update_vars(self, model, in_dataset):
@@ -333,7 +333,7 @@ class TestSimlabAccessor:
         ds["clock"] = (
             "clock",
             [0, 2, 4, 6, 8],
-            {self._clock_key: 1, self._master_clock_key: 1},
+            {self._clock_key: 1, self._main_clock_key: 1},
         )
         ds["out"] = ("out", [0, 4, 8], {self._clock_key: 1})
         ds["not_a_clock"] = ("not_a_clock", [0, 1])

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -505,7 +505,7 @@ class SimlabAccessor:
 
         if master_clock is not None:
             warnings.warn(
-                "master_clock is to be deprecated in favour ofmain_clock",
+                "master_clock is to be deprecated in favour of main_clock",
                 FutureWarning,
             )
             main_clock = master_clock
@@ -857,7 +857,7 @@ def create_setup(
         :class:`xarray.IndexVariable` objects (e.g., a 1-d
         :class:`numpy.ndarray` or a :class:`pandas.Index`).
     master_clock: str or dict, optional
-        Seemain_clock to be deprecated
+        See main_clock to be deprecated
     main_clock : str or dict, optional
         Name of the clock coordinate (dimension) to use as main clock.
         If not set, the name is inferred from ``clocks`` (only if
@@ -921,7 +921,7 @@ def create_setup(
 
     if master_clock is not None:
         warnings.warn(
-            "master_clock is to be deprecated in favour ofmain_clock",
+            "master_clock is to be deprecated in favour of main_clock",
             FutureWarning,
         )
         main_clock = master_clock

--- a/xsimlab/xr_accessor.py
+++ b/xsimlab/xr_accessor.py
@@ -128,12 +128,12 @@ class SimlabAccessor:
     """Simlab extension to :class:`xarray.Dataset`."""
 
     _clock_key = "__xsimlab_output_clock__"
-    _master_clock_key = "__xsimlab_master_clock__"
+    _main_clock_key = "__xsimlab_main_clock__"
     _output_vars_key = "__xsimlab_output_vars__"
 
     def __init__(self, ds):
         self._ds = ds
-        self._master_clock_dim = None
+        self._main_clock_dim = None
         self._clock_coords = None
 
     @property
@@ -161,9 +161,9 @@ class SimlabAccessor:
         return Frozen({k: coord.size for k, coord in self.clock_coords.items()})
 
     @property
-    def master_clock_dim(self):
-        """Dimension used as master clock for model runs. Returns None
-        if no dimension is set as master clock.
+    def main_clock_dim(self):
+        """Dimension used as main clock for model runs. Returns None
+        if no dimension is set as main clock.
 
         See Also
         --------
@@ -171,39 +171,39 @@ class SimlabAccessor:
 
         """
         # it is fine to cache the value here as inconsistency may appear
-        # only when deleting the master clock coordinate from the dataset,
+        # only when deleting the main clock coordinate from the dataset,
         # which would raise early anyway
 
-        if self._master_clock_dim is not None:
-            return self._master_clock_dim
+        if self._main_clock_dim is not None:
+            return self._main_clock_dim
         else:
             for c in self._ds.coords.values():
-                if c.attrs.get(self._master_clock_key, False):
+                if c.attrs.get(self._main_clock_key, False):
                     dim = c.dims[0]
-                    self._master_clock_dim = dim
+                    self._main_clock_dim = dim
                     return dim
             return None
 
     @property
-    def master_clock_coord(self):
-        """Master clock coordinate (as a :class:`xarray.DataArray` object).
+    def main_clock_coord(self):
+        """Main clock coordinate (as a :class:`xarray.DataArray` object).
 
-        Returns None if no master clock is defined in the dataset.
+        Returns None if no main clock is defined in the dataset.
         """
-        return self._ds.get(self.master_clock_dim)
+        return self._ds.get(self.main_clock_dim)
 
     @property
     def nsteps(self):
         """Number of simulation steps, computed from the master
         clock coordinate.
 
-        Returns 0 if no master clock is defined in the dataset.
+        Returns 0 if no main clock is defined in the dataset.
 
         """
-        if self.master_clock_dim is None:
+        if self.main_clock_dim is None:
             return 0
         else:
-            return self._ds[self.master_clock_dim].size - 1
+            return self._ds[self.main_clock_dim].size - 1
 
     def get_output_save_steps(self):
         """Returns save steps for each clock as boolean values.
@@ -212,16 +212,16 @@ class SimlabAccessor:
         -------
         save_steps : :class:`xarray.Dataset`
             A new Dataset with boolean data variables for each clock
-            dimension other than the master clock, where values specify
+            dimension other than the main clock, where values specify
             whether or not to save outputs at every step of a simulation.
 
         """
-        ds = Dataset(coords={self.master_clock_dim: self.master_clock_coord})
+        ds = Dataset(coords={self.main_clock_dim: self.main_clock_coord})
 
         for clock, coord in self.clock_coords.items():
-            if clock != self.master_clock_dim:
-                save_steps = np.in1d(self.master_clock_coord.values, coord.values)
-                ds[clock] = (self.master_clock_dim, save_steps)
+            if clock != self.main_clock_dim:
+                save_steps = np.in1d(self.main_clock_coord.values, coord.values)
+                ds[clock] = (self.main_clock_dim, save_steps)
 
         return ds
 
@@ -242,26 +242,26 @@ class SimlabAccessor:
     def _uniformize_clock_coords(self, dim=None, units=None, calendar=None):
         """Ensure consistency across all clock coordinates.
 
-        - maybe update master clock dimension
+        - maybe update main clock dimension
         - maybe set or update the same units and/or calendar for all
           coordinates as attributes
-        - check that all clocks are synchronized with master clock, i.e.,
-          there is no coordinate label that is not present in master clock
+        - check that all clocks are synchronized with main clock, i.e.,
+          there is no coordinate label that is not present in main clock
 
         """
         if dim is not None:
-            if self.master_clock_dim is not None:
-                old_mclock_coord = self._ds[self.master_clock_dim]
-                old_mclock_coord.attrs.pop(self._master_clock_key)
+            if self.main_clock_dim is not None:
+                old_mclock_coord = self._ds[self.main_clock_dim]
+                old_mclock_coord.attrs.pop(self._main_clock_key)
 
             if dim not in self._ds.coords:
                 raise KeyError(
-                    f"Master clock dimension name {dim} as no "
+                    f"Main clock dimension name {dim} as no "
                     "defined coordinate in Dataset"
                 )
 
-            self._ds[dim].attrs[self._master_clock_key] = np.uint8(True)
-            self._master_clock_dim = dim
+            self._ds[dim].attrs[self._main_clock_key] = np.uint8(True)
+            self._main_clock_dim = dim
 
         if units is not None:
             for coord in self.clock_coords.values():
@@ -271,21 +271,21 @@ class SimlabAccessor:
             for coord in self.clock_coords.values():
                 coord.attrs["calendar"] = calendar
 
-        master_clock_idx = self._ds.indexes.get(self.master_clock_dim)
+        main_clock_idx = self._ds.indexes.get(self.main_clock_dim)
 
         for clock_dim in self.clock_coords:
-            if clock_dim == self.master_clock_dim:
+            if clock_dim == self.main_clock_dim:
                 continue
 
             clock_idx = self._ds.indexes[clock_dim]
-            diff_idx = clock_idx.difference(master_clock_idx)
+            diff_idx = clock_idx.difference(main_clock_idx)
 
             if diff_idx.size:
                 raise ValueError(
                     f"Clock coordinate {clock_dim} is not synchronized "
-                    f"with master clock coordinate {self.master_clock_dim}. "
+                    f"with main clock coordinate {self.main_clock_dim}. "
                     "The following coordinate labels are "
-                    f"absent in master clock: {diff_idx.values}"
+                    f"absent in main clock: {diff_idx.values}"
                 )
 
     def _set_input_vars(self, model, input_vars):
@@ -460,7 +460,9 @@ class SimlabAccessor:
 
         return Frozen(dict(o_vars))
 
-    def update_clocks(self, model=None, clocks=None, master_clock=None):
+    def update_clocks(
+        self, model=None, clocks=None, main_clock=None, master_clock=None
+    ):
         """Set or update clock coordinates.
 
         Also copy from the replaced coordinates any attribute that is
@@ -475,16 +477,17 @@ class SimlabAccessor:
             values are anything that can be easily converted to
             :class:`xarray.IndexVariable` objects (e.g., a 1-d
             :class:`numpy.ndarray` or a :class:`pandas.Index`).
-        master_clock : str or dict, optional
-            Name of the clock coordinate (dimension) to use as master clock.
+        main_clock : str or dict, optional
+            Name of the clock coordinate (dimension) to use as main clock.
             If not set, the name is inferred from ``clocks`` (only if
-            one coordinate is given and if Dataset has no master clock
+            one coordinate is given and if Dataset has no main clock
             defined yet).
             A dictionary can also be given with one of several of these keys:
 
-            - ``dim`` : name of the master clock dimension/coordinate
+            - ``dim`` : name of the main clock dimension/coordinate
             - ``units`` : units of all clock coordinate labels
             - ``calendar`` : a unique calendar for all (time) clock coordinates
+        master_clock : same as `main_clock`, to be deprecated
 
         Returns
         -------
@@ -500,42 +503,44 @@ class SimlabAccessor:
 
         ds = self._ds.copy()
 
-        if isinstance(master_clock, str):
-            master_clock_dict = {"dim": master_clock}
+        if master_clock is not None:
+            warnings.warn(
+                "master_clock is to be deprecated in favour ofmain_clock",
+                FutureWarning,
+            )
+            main_clock = master_clock
 
-        elif master_clock is None:
-            if (
-                clocks is not None
-                and len(clocks) == 1
-                and self.master_clock_dim is None
-            ):
-                master_clock_dict = {"dim": list(clocks.keys())[0]}
+        if isinstance(main_clock, str):
+            main_clock_dict = {"dim": main_clock}
+
+        elif main_clock is None:
+            if clocks is not None and len(clocks) == 1 and self.main_clock_dim is None:
+                main_clock_dict = {"dim": list(clocks.keys())[0]}
             else:
-                master_clock_dict = {"dim": self.master_clock_dim}
+                main_clock_dict = {"dim": self.main_clock_dim}
 
         else:
-            master_clock_dict = master_clock
+            main_clock_dict = main_clock
 
-        master_clock_dim = master_clock_dict.get("dim", self.master_clock_dim)
+        main_clock_dim = main_clock_dict.get("dim", self.main_clock_dim)
 
         if clocks is not None:
-            if master_clock_dim is None:
+            if main_clock_dim is None:
                 raise ValueError(
-                    "Cannot determine which clock coordinate is the master clock"
+                    "Cannot determine which clock coordinate is the main clock"
                 )
             elif (
-                master_clock_dim not in clocks
-                and master_clock_dim not in self.clock_coords
+                main_clock_dim not in clocks and main_clock_dim not in self.clock_coords
             ):
                 raise KeyError(
-                    f"Master clock dimension name {master_clock_dim!r} not found "
+                    f"Main clock dimension name {main_clock_dim!r} not found "
                     "in `clocks` nor in Dataset"
                 )
 
             for dim, data in clocks.items():
                 ds.xsimlab._set_clock_coord(dim, data)
 
-        ds.xsimlab._uniformize_clock_coords(**master_clock_dict)
+        ds.xsimlab._uniformize_clock_coords(**main_clock_dict)
 
         # operations on clock coords may have discarded coord attributes
         o_vars = {k: v for k, v in self.output_vars.items() if v is None or v in ds}
@@ -829,6 +834,7 @@ def create_setup(
     model=None,
     clocks=None,
     master_clock=None,
+    main_clock=None,
     input_vars=None,
     output_vars=None,
     fill_default=True,
@@ -850,14 +856,16 @@ def create_setup(
         values are anything that can be easily converted to
         :class:`xarray.IndexVariable` objects (e.g., a 1-d
         :class:`numpy.ndarray` or a :class:`pandas.Index`).
-    master_clock : str or dict, optional
-        Name of the clock coordinate (dimension) to use as master clock.
+    master_clock: str or dict, optional
+        Seemain_clock to be deprecated
+    main_clock : str or dict, optional
+        Name of the clock coordinate (dimension) to use as main clock.
         If not set, the name is inferred from ``clocks`` (only if
-        one coordinate is given and if Dataset has no master clock
+        one coordinate is given and if Dataset has no main clock
         defined yet).
         A dictionary can also be given with one of several of these keys:
 
-        - ``dim`` : name of the master clock dimension/coordinate
+        - ``dim`` : name of the main clock dimension/coordinate
         - ``units`` : units of all clock coordinate labels
         - ``calendar`` : a unique calendar for all (time) clock coordinates
     input_vars : dict, optional
@@ -911,9 +919,16 @@ def create_setup(
         else:
             return ds
 
+    if master_clock is not None:
+        warnings.warn(
+            "master_clock is to be deprecated in favour ofmain_clock",
+            FutureWarning,
+        )
+        main_clock = master_clock
+
     ds = (
         Dataset()
-        .xsimlab.update_clocks(model=model, clocks=clocks, master_clock=master_clock)
+        .xsimlab.update_clocks(model=model, clocks=clocks, main_clock=main_clock)
         .pipe(maybe_fill_default)
         .xsimlab.update_vars(
             model=model, input_vars=input_vars, output_vars=output_vars


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
Changed 'master' to main in the entire codebase. API still accepts `master_clock`, but gives a FutureWarning (2 instances in `xr_accessor.py`). Also changed tests where they were broken (when they used internal master values). 

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `black . && flake8`
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API
